### PR TITLE
Chunk status alert

### DIFF
--- a/src/main/java/ru/octol1ttle/flightassistant/FAModMenuImpl.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/FAModMenuImpl.java
@@ -330,6 +330,13 @@ public class FAModMenuImpl implements ModMenuApi {
                         .controller(TickBoxControllerBuilder::create)
                         .build())
 
+                .option(LabelOption.create(Text.translatable("config.flightassistant.computers.chunk_state")))
+                .option(Option.<ComputerConfig.ProtectionMode>createBuilder()
+                        .name(Text.translatable("config.flightassistant.computers.chunk_state.protection"))
+                        .binding(defaults.unloadedChunkProtection, () -> config.unloadedChunkProtection, o -> config.unloadedChunkProtection = o)
+                        .controller(opt -> EnumControllerBuilder.create(opt).enumClass(ComputerConfig.ProtectionMode.class))
+                        .build())
+
                 .build();
     }
 }

--- a/src/main/java/ru/octol1ttle/flightassistant/alerts/nav/UnloadedChunkAlert.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/alerts/nav/UnloadedChunkAlert.java
@@ -1,0 +1,37 @@
+package ru.octol1ttle.flightassistant.alerts.nav;
+
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
+import ru.octol1ttle.flightassistant.HudComponent;
+import ru.octol1ttle.flightassistant.alerts.AlertSoundData;
+import ru.octol1ttle.flightassistant.alerts.BaseAlert;
+import ru.octol1ttle.flightassistant.alerts.IECAMAlert;
+import ru.octol1ttle.flightassistant.computers.safety.ChunkStatusComputer;
+
+public class UnloadedChunkAlert extends BaseAlert implements IECAMAlert {
+
+    private final ChunkStatusComputer chunkStatus;
+
+    public UnloadedChunkAlert(ChunkStatusComputer chunkStatus) {
+        this.chunkStatus = chunkStatus;
+    }
+
+    @Override
+    public boolean isTriggered() {
+        return chunkStatus.isInWarning();
+    }
+
+    @Override
+    public int render(TextRenderer textRenderer, DrawContext context, int x, int y, boolean highlight) {
+        return HudComponent.drawHighlightedText(textRenderer, context, Text.translatable("alerts.flightassistant.unloaded_chunk"), x, y,
+                chunkStatus.getIndicator(), highlight);
+    }
+
+    @Override
+    public @NotNull AlertSoundData getSoundData() {
+        return AlertSoundData.MASTER_WARNING;
+    }
+
+}

--- a/src/main/java/ru/octol1ttle/flightassistant/alerts/nav/UnloadedChunkAlert.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/alerts/nav/UnloadedChunkAlert.java
@@ -9,9 +9,9 @@ import ru.octol1ttle.flightassistant.alerts.AlertSoundData;
 import ru.octol1ttle.flightassistant.alerts.BaseAlert;
 import ru.octol1ttle.flightassistant.alerts.IECAMAlert;
 import ru.octol1ttle.flightassistant.computers.safety.ChunkStatusComputer;
+import ru.octol1ttle.flightassistant.config.FAConfig;
 
 public class UnloadedChunkAlert extends BaseAlert implements IECAMAlert {
-
     private final ChunkStatusComputer chunkStatus;
 
     public UnloadedChunkAlert(ChunkStatusComputer chunkStatus) {
@@ -26,12 +26,11 @@ public class UnloadedChunkAlert extends BaseAlert implements IECAMAlert {
     @Override
     public int render(TextRenderer textRenderer, DrawContext context, int x, int y, boolean highlight) {
         return HudComponent.drawHighlightedText(textRenderer, context, Text.translatable("alerts.flightassistant.unloaded_chunk"), x, y,
-                chunkStatus.getIndicator(), highlight);
+                FAConfig.indicator().warningColor, highlight);
     }
 
     @Override
     public @NotNull AlertSoundData getSoundData() {
         return AlertSoundData.MASTER_WARNING;
     }
-
 }

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/ComputerHost.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/ComputerHost.java
@@ -40,7 +40,7 @@ public class ComputerHost {
         this.data = new AirDataComputer(mc);
         this.time = new TimeComputer();
         this.firework = new FireworkController(mc, data, time);
-        this.chunkStatus = new ChunkStatusComputer(this, mc, data, time);
+        this.chunkStatus = new ChunkStatusComputer(mc, data, time);
         this.stall = new StallComputer(firework, data);
         this.voidLevel = new VoidLevelComputer(data, firework, stall);
         this.plan = new FlightPlanner(data);

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/ComputerHost.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/ComputerHost.java
@@ -13,6 +13,7 @@ import ru.octol1ttle.flightassistant.computers.autoflight.PitchController;
 import ru.octol1ttle.flightassistant.computers.autoflight.YawController;
 import ru.octol1ttle.flightassistant.computers.navigation.FlightPlanner;
 import ru.octol1ttle.flightassistant.computers.safety.AlertController;
+import ru.octol1ttle.flightassistant.computers.safety.ChunkStatusComputer;
 import ru.octol1ttle.flightassistant.computers.safety.ElytraStateController;
 import ru.octol1ttle.flightassistant.computers.safety.GPWSComputer;
 import ru.octol1ttle.flightassistant.computers.safety.StallComputer;
@@ -21,6 +22,7 @@ import ru.octol1ttle.flightassistant.computers.safety.VoidLevelComputer;
 public class ComputerHost {
     public final AirDataComputer data;
     public final StallComputer stall;
+    public final ChunkStatusComputer chunkStatus;
     public final GPWSComputer gpws;
     public final VoidLevelComputer voidLevel;
     public final FireworkController firework;
@@ -38,6 +40,7 @@ public class ComputerHost {
         this.data = new AirDataComputer(mc);
         this.time = new TimeComputer();
         this.firework = new FireworkController(mc, data, time);
+        this.chunkStatus = new ChunkStatusComputer(this, mc, data, time);
         this.stall = new StallComputer(firework, data);
         this.voidLevel = new VoidLevelComputer(data, firework, stall);
         this.plan = new FlightPlanner(data);
@@ -45,7 +48,7 @@ public class ComputerHost {
         this.elytra = new ElytraStateController(data);
 
         this.yaw = new YawController(time, data);
-        this.pitch = new PitchController(data, stall, time, voidLevel, gpws);
+        this.pitch = new PitchController(data, stall, time, voidLevel, gpws, chunkStatus);
 
         this.autoflight = new AutoFlightComputer(data, gpws, plan, firework, pitch, yaw);
 
@@ -53,7 +56,7 @@ public class ComputerHost {
 
         // computers are sorted in the order they should be ticked to avoid errors
         this.tickables = new ArrayList<>(List.of(
-                data, time, stall, gpws, voidLevel, elytra, plan, autoflight, firework, alert, pitch, yaw
+                data, time, stall, chunkStatus, gpws, voidLevel, elytra, plan, autoflight, firework, alert, pitch, yaw
         ));
         Collections.reverse(this.tickables); // we tick computers in reverse, so reverse the collections so that the order is correct
 

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/autoflight/PitchController.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/autoflight/PitchController.java
@@ -49,11 +49,10 @@ public class PitchController implements ITickableComputer {
         } else if (gpws.shouldCorrectTerrain()) {
             smoothSetPitch(FAMathHelper.toDegrees(MathHelper.atan2(gpws.terrainAvoidVector.y, gpws.terrainAvoidVector.x)), time.deltaTime);
         } else if (chunkStatus.shouldCorrectTerrain()) {
-            smoothSetPitch(chunkStatus.recoverPitch, time.deltaTime);
+            smoothSetPitch(VoidLevelComputer.OPTIMUM_ALTITUDE_PRESERVATION_PITCH, time.deltaTime);
         } else {
             smoothSetPitch(targetPitch, time.deltaTime);
         }
-
     }
 
     /**

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/autoflight/PitchController.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/autoflight/PitchController.java
@@ -5,6 +5,7 @@ import ru.octol1ttle.flightassistant.FAMathHelper;
 import ru.octol1ttle.flightassistant.computers.AirDataComputer;
 import ru.octol1ttle.flightassistant.computers.ITickableComputer;
 import ru.octol1ttle.flightassistant.computers.TimeComputer;
+import ru.octol1ttle.flightassistant.computers.safety.ChunkStatusComputer;
 import ru.octol1ttle.flightassistant.computers.safety.GPWSComputer;
 import ru.octol1ttle.flightassistant.computers.safety.StallComputer;
 import ru.octol1ttle.flightassistant.computers.safety.VoidLevelComputer;
@@ -19,14 +20,16 @@ public class PitchController implements ITickableComputer {
     private final TimeComputer time;
     private final VoidLevelComputer voidLevel;
     private final GPWSComputer gpws;
+    private final ChunkStatusComputer chunkStatus;
     public Float targetPitch = null;
 
-    public PitchController(AirDataComputer data, StallComputer stall, TimeComputer time, VoidLevelComputer voidLevel, GPWSComputer gpws) {
+    public PitchController(AirDataComputer data, StallComputer stall, TimeComputer time, VoidLevelComputer voidLevel, GPWSComputer gpws, ChunkStatusComputer chunkStatus) {
         this.data = data;
         this.stall = stall;
         this.time = time;
         this.voidLevel = voidLevel;
         this.gpws = gpws;
+        this.chunkStatus = chunkStatus;
     }
 
     @Override
@@ -45,9 +48,12 @@ public class PitchController implements ITickableComputer {
             smoothSetPitch(90.0f, MathHelper.clamp(time.deltaTime / gpws.descentImpactTime, 0.001f, 1.0f));
         } else if (gpws.shouldCorrectTerrain()) {
             smoothSetPitch(FAMathHelper.toDegrees(MathHelper.atan2(gpws.terrainAvoidVector.y, gpws.terrainAvoidVector.x)), time.deltaTime);
+        } else if (chunkStatus.shouldCorrectTerrain()) {
+            smoothSetPitch(chunkStatus.recoverPitch, time.deltaTime);
         } else {
             smoothSetPitch(targetPitch, time.deltaTime);
         }
+
     }
 
     /**

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/safety/AlertController.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/safety/AlertController.java
@@ -19,6 +19,7 @@ import ru.octol1ttle.flightassistant.alerts.nav.ApproachingVoidDamageLevelAlert;
 import ru.octol1ttle.flightassistant.alerts.nav.MinimumsAlert;
 import ru.octol1ttle.flightassistant.alerts.nav.gpws.ExcessiveDescentAlert;
 import ru.octol1ttle.flightassistant.alerts.nav.gpws.ExcessiveTerrainClosureAlert;
+import ru.octol1ttle.flightassistant.alerts.nav.UnloadedChunkAlert;
 import ru.octol1ttle.flightassistant.alerts.nav.gpws.UnsafeTerrainClearanceAlert;
 import ru.octol1ttle.flightassistant.alerts.other.ElytraHealthLowAlert;
 import ru.octol1ttle.flightassistant.alerts.other.StallAlert;
@@ -37,6 +38,7 @@ public class AlertController implements ITickableComputer {
         // TODO: ECAM actions
         allAlerts = List.of(
                 new StallAlert(host.stall),
+                new UnloadedChunkAlert(host.chunkStatus),
                 new ExcessiveDescentAlert(host.data, host.gpws), new ExcessiveTerrainClosureAlert(host.gpws, host.time),
                 new UnsafeTerrainClearanceAlert(host.gpws, host.plan),
                 new AutopilotOffAlert(host.autoflight), new AutoFireworkOffAlert(host.autoflight),

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
@@ -22,6 +22,7 @@ public class ChunkStatusComputer implements ITickableComputer {
     private float lastEncounteredMS = 0f;
     private float lastDiffMS = 0f;
     private float offsetMS = 0f; // for single player pause
+    private boolean changesPending; // reset state when not flying
 
     // milliseconds difference
     private static final float WARN_THRESHOLD = 3200f;
@@ -36,7 +37,14 @@ public class ChunkStatusComputer implements ITickableComputer {
     @Override
     public void tick() {
         if (!data.isFlying()) {
+            if (changesPending) {
+                reset();
+            }
             return;
+        }
+
+        if (!changesPending) {
+            changesPending = true;
         }
 
         isLoaded = data.isCurrentChunkLoaded;
@@ -73,6 +81,7 @@ public class ChunkStatusComputer implements ITickableComputer {
         lastDiffMS = 0f;
         lastEncounteredMS = 0f;
         offsetMS = 0f;
+        changesPending = false;
     }
 
     public boolean shouldCorrectTerrain() {

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
@@ -1,0 +1,100 @@
+package ru.octol1ttle.flightassistant.computers.safety;
+
+import net.minecraft.client.MinecraftClient;
+import ru.octol1ttle.flightassistant.computers.AirDataComputer;
+import ru.octol1ttle.flightassistant.computers.ComputerHost;
+import ru.octol1ttle.flightassistant.computers.ITickableComputer;
+import ru.octol1ttle.flightassistant.computers.TimeComputer;
+import ru.octol1ttle.flightassistant.config.FAConfig;
+
+import java.awt.Color;
+
+public class ChunkStatusComputer implements ITickableComputer {
+
+    private final ComputerHost host;
+    private final MinecraftClient mc;
+    private final AirDataComputer data;
+    private final TimeComputer time;
+
+    public final float recoverPitch = 10f;
+    private boolean isInWarning;
+    private boolean isLoaded;
+    private float lastEncounteredMS = 0f;
+    private float lastDiffMS = 0f;
+    private float offsetMS = 0f; // for single player pause
+
+    // milliseconds difference
+    private static final float WARN_THRESHOLD = 3200f;
+
+    public ChunkStatusComputer(ComputerHost host, MinecraftClient mc, AirDataComputer data, TimeComputer time) {
+        this.host = host;
+        this.mc = mc;
+        this.data = data;
+        this.time = time;
+    }
+
+    @Override
+    public void tick() {
+        if (!data.isFlying()) {
+            return;
+        }
+
+        isLoaded = data.isCurrentChunkLoaded;
+
+        if (isLoaded) {
+            if (!host.faulted.contains(time) && time.prevMillis != null) {
+                lastEncounteredMS = time.prevMillis;
+            }
+            isLoaded = false;
+            offsetMS = 0f;
+        }
+
+        final boolean isSinglePlayerPause = (mc.isInSingleplayer() && mc.isPaused());
+        if (isSinglePlayerPause && !isLoaded) {
+            offsetMS = ((time.prevMillis - lastEncounteredMS) - lastDiffMS);
+        }
+
+        if (time.prevMillis != null && lastEncounteredMS > 0f) {
+            lastDiffMS = (time.prevMillis - offsetMS) - lastEncounteredMS;
+        }
+
+        isInWarning = shouldWarn();
+    }
+
+    @Override
+    public String getId() {
+        return "chunk_state";
+    }
+
+    @Override
+    public void reset() {
+        isInWarning = false;
+        isLoaded = true;
+        lastDiffMS = 0f;
+        lastEncounteredMS = 0f;
+        offsetMS = 0f;
+    }
+
+    public boolean shouldCorrectTerrain() {
+        return FAConfig.computer().unloadedChunkProtection.recover() && isInWarning();
+    }
+
+    public boolean isInWarning() {
+        return isInWarning;
+    }
+
+    public float getLastDiffMS() {
+        return lastDiffMS;
+    }
+
+    public Color getIndicator() {
+        return FAConfig.indicator().warningColor;
+    }
+
+    private boolean shouldWarn() {
+        if (data.isFlying() && !data.isCurrentChunkLoaded) {
+            return lastDiffMS >= WARN_THRESHOLD;
+        }
+        return false;
+    }
+}

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/safety/ChunkStatusComputer.java
@@ -2,33 +2,24 @@ package ru.octol1ttle.flightassistant.computers.safety;
 
 import net.minecraft.client.MinecraftClient;
 import ru.octol1ttle.flightassistant.computers.AirDataComputer;
-import ru.octol1ttle.flightassistant.computers.ComputerHost;
 import ru.octol1ttle.flightassistant.computers.ITickableComputer;
 import ru.octol1ttle.flightassistant.computers.TimeComputer;
 import ru.octol1ttle.flightassistant.config.FAConfig;
 
-import java.awt.Color;
-
 public class ChunkStatusComputer implements ITickableComputer {
-
-    private final ComputerHost host;
     private final MinecraftClient mc;
     private final AirDataComputer data;
     private final TimeComputer time;
 
-    public final float recoverPitch = 10f;
     private boolean isInWarning;
-    private boolean isLoaded;
     private float lastEncounteredMS = 0f;
     private float lastDiffMS = 0f;
     private float offsetMS = 0f; // for single player pause
-    private boolean changesPending; // reset state when not flying
 
     // milliseconds difference
     private static final float WARN_THRESHOLD = 3200f;
 
-    public ChunkStatusComputer(ComputerHost host, MinecraftClient mc, AirDataComputer data, TimeComputer time) {
-        this.host = host;
+    public ChunkStatusComputer(MinecraftClient mc, AirDataComputer data, TimeComputer time) {
         this.mc = mc;
         this.data = data;
         this.time = time;
@@ -37,28 +28,19 @@ public class ChunkStatusComputer implements ITickableComputer {
     @Override
     public void tick() {
         if (!data.isFlying()) {
-            if (changesPending) {
-                reset();
-            }
+            reset();
             return;
         }
 
-        if (!changesPending) {
-            changesPending = true;
-        }
-
-        isLoaded = data.isCurrentChunkLoaded;
-
-        if (isLoaded) {
-            if (!host.faulted.contains(time) && time.prevMillis != null) {
+        if (data.isCurrentChunkLoaded) {
+            if (time.prevMillis != null) {
                 lastEncounteredMS = time.prevMillis;
             }
-            isLoaded = false;
             offsetMS = 0f;
         }
 
         final boolean isSinglePlayerPause = (mc.isInSingleplayer() && mc.isPaused());
-        if (isSinglePlayerPause && !isLoaded) {
+        if (isSinglePlayerPause && !data.isCurrentChunkLoaded) {
             offsetMS = ((time.prevMillis - lastEncounteredMS) - lastDiffMS);
         }
 
@@ -67,21 +49,6 @@ public class ChunkStatusComputer implements ITickableComputer {
         }
 
         isInWarning = shouldWarn();
-    }
-
-    @Override
-    public String getId() {
-        return "chunk_state";
-    }
-
-    @Override
-    public void reset() {
-        isInWarning = false;
-        isLoaded = true;
-        lastDiffMS = 0f;
-        lastEncounteredMS = 0f;
-        offsetMS = 0f;
-        changesPending = false;
     }
 
     public boolean shouldCorrectTerrain() {
@@ -96,14 +63,23 @@ public class ChunkStatusComputer implements ITickableComputer {
         return lastDiffMS;
     }
 
-    public Color getIndicator() {
-        return FAConfig.indicator().warningColor;
-    }
-
     private boolean shouldWarn() {
         if (data.isFlying() && !data.isCurrentChunkLoaded) {
             return lastDiffMS >= WARN_THRESHOLD;
         }
         return false;
+    }
+
+    @Override
+    public String getId() {
+        return "chunk_state";
+    }
+
+    @Override
+    public void reset() {
+        isInWarning = false;
+        lastDiffMS = 0f;
+        lastEncounteredMS = 0f;
+        offsetMS = 0f;
     }
 }

--- a/src/main/java/ru/octol1ttle/flightassistant/computers/safety/VoidLevelComputer.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/computers/safety/VoidLevelComputer.java
@@ -7,7 +7,7 @@ import ru.octol1ttle.flightassistant.computers.autoflight.PitchController;
 import ru.octol1ttle.flightassistant.config.FAConfig;
 
 public class VoidLevelComputer implements ITickableComputer {
-    private static final int OPTIMUM_ALTITUDE_PRESERVATION_PITCH = 15;
+    public static final float OPTIMUM_ALTITUDE_PRESERVATION_PITCH = 15f;
     private final AirDataComputer data;
     private final FireworkController firework;
     private final StallComputer stall;

--- a/src/main/java/ru/octol1ttle/flightassistant/config/ComputerConfig.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/config/ComputerConfig.java
@@ -42,6 +42,9 @@ public class ComputerConfig {
     @SerialEntry
     public boolean openElytraAutomatically = true;
 
+    @SerialEntry
+    public ProtectionMode unloadedChunkProtection = ProtectionMode.HARD;
+
     public enum GlobalAutomationsMode implements NameableEnum {
         FULL,
         // TODO: LIMIT TO NO_OVERLAYS ON SERVERS

--- a/src/main/java/ru/octol1ttle/flightassistant/indicators/AltitudeIndicator.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/indicators/AltitudeIndicator.java
@@ -54,9 +54,13 @@ public class AltitudeIndicator extends HudComponent {
 
         if (FAConfig.indicator().showGroundAltitude) {
             Color color = data.altitude() < safeLevel ? FAConfig.indicator().warningColor : FAConfig.indicator().frameColor;
-            drawText(textRenderer, context, Text.translatable(data.groundLevel == data.voidLevel() ? "flightassistant.void_level" : "flightassistant.ground_level"), xAltText - 10, bottom, color);
-            drawText(textRenderer, context, asText("%d", MathHelper.floor(data.heightAboveGround())), xAltText, bottom, color);
-            drawBorder(context, xAltText - 2, bottom - 2, 28, color);
+            if (!data.isCurrentChunkLoaded) {
+                drawText(textRenderer, context, Text.translatable("flightassistant.altitude_short"), xAltText, bottom, FAConfig.indicator().warningColor);
+            } else {
+                drawText(textRenderer, context, Text.translatable(data.groundLevel == data.voidLevel() ? "flightassistant.void_level" : "flightassistant.ground_level"), xAltText - 10, bottom, color);
+                drawText(textRenderer, context, asText("%d", MathHelper.floor(data.heightAboveGround())), xAltText, bottom, color);
+                drawBorder(context, xAltText - 2, bottom - 2, 28, color);
+            }
         }
 
         if (FAConfig.indicator().showAltitudeScale) {

--- a/src/main/resources/assets/flightassistant/lang/en_us.json
+++ b/src/main/resources/assets/flightassistant/lang/en_us.json
@@ -82,6 +82,8 @@
   "config.flightassistant.computers.elytra_state": "Elytra state",
   "config.flightassistant.computers.elytra_state.close_underwater": "Close Elytra when submerged in water",
   "config.flightassistant.computers.elytra_state.open_automatically": "Open Elytra automatically",
+  "config.flightassistant.computers.chunk_state": "Chunk state",
+  "config.flightassistant.computers.chunk_state.protection": "Chunk state protection mode",
 
   "commands.flightassistant.no_such_waypoint": "There is no waypoint at that index",
   "commands.flightassistant.no_such_plan": "There is no plan with that name",
@@ -107,6 +109,7 @@
   "alerts.flightassistant.stall": "STALL",
   "alerts.flightassistant.terrain_ahead": "TERRAIN AHEAD",
   "alerts.flightassistant.too_low_terrain": "TOO LOW - TERRAIN",
+  "alerts.flightassistant.unloaded_chunk": "UNLOADED CHUNK",
 
   "alerts.flightassistant.elytra_health_low": "ELYTRA HEALTH LOW",
 
@@ -130,6 +133,7 @@
   "alerts.flightassistant.fault.computers.void_level": "VOID LVL FAULT (PROT LOST)",
   "alerts.flightassistant.fault.computers.yaw_ctl": "YAW CTL FAULT",
   "alerts.flightassistant.fault.computers.elytra_state": "ELYTRA STATE FAULT (PROT LOST)",
+  "alerts.flightassistant.fault.computers.chunk_state": "CHUNK STATE FAULT (PROT LOST)",
   "alerts.flightassistant.fault.indicators.alert": "ALERT INDICATOR FAULT",
   "alerts.flightassistant.fault.indicators.altitude": "ALTITUDE INDICATOR FAULT",
   "alerts.flightassistant.fault.indicators.elytra_health": "ELYTRA HEALTH INDICATOR FAULT",


### PR DESCRIPTION
This PR add some feature for chunk status, as follow.

Indicate if current chunk is unloaded, use last ground height as reference.

Player will receive an alert when they fly into unloaded chunk after a certain amount of time. After 3.2 seconds, alert will be shown and will pitch up by ~10 degrees if enabled.

Screenshot
![image](https://i.imgur.com/epW1ao8.png)