### PR TITLE
[Unofficial Port] Update FlightAssistant to Minecraft 26.2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align=center>
-    <img src="images/logo.png">
+    <img src="images/logo.png" alt="FlightAssistant Logo">
 </p>
 
 <p align=center>
-    <a href="https://modrinth.com/mod/flightassistant">
+    <a href="https://modrinth.com/mod/flightassistant-26-2-port">
         <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/cozy/available/modrinth_vector.svg"
             alt="Available on Modrinth"></a>
     <a href="https://modrinth.com/mod/fabric-api/">
@@ -25,14 +25,14 @@
 
 - Fully customizable flight HUD ([wiki](https://github.com/Octol1ttle/FlightAssistant/wiki/HUD))
   - An informative display showing flight data in real time
-    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/full_screenshot_alt.png">
+    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/full_screenshot_alt.png" alt="HUD screenshot 1">
 - Smart flight safety alerts ([wiki](https://github.com/Octol1ttle/FlightAssistant/wiki/Alerts))
   - Be aware of unsafe flight conditions before it's too late
-    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/alert_display_alt.png">
+    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/alert_display_alt.png" alt="Alert screenshot">
 - Non-intrusive automatic flight protections ([wiki](https://github.com/Octol1ttle/FlightAssistant/wiki/Flight-protections))
   - When you're not paying attention, FlightAssistant will protect you
   - Examples: ground collision damage avoidance, void damage avoidance, automatic elytra deploying
 - Advanced autopilot with flight planning capabilities: fly safely completely hands-free ([wiki](https://github.com/Octol1ttle/FlightAssistant/wiki/Autopilot%3A-overview-and-basics))
   - Flight plans can be saved to disk and loaded later
   - With flight plans, a flight can be performed completely automatically from takeoff to landing
-    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/full_screenshot.png">
+    <img src="https://github.com/Octol1ttle/FlightAssistant/wiki/img/hud/full_screenshot.png" alt="HUD screenshot 2">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align=center>
-    <img src="images/logo.png" alt="FlightAssistant Logo">
+    <img src="https://raw.githubusercontent.com/Henner4746/FlightAssistant/dev/images/logo.png" alt="FlightAssistant Logo">
 </p>
 
 <p align=center>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align=center>
-    <a href="https://modrinth.com/mod/flightassistant-26-2-port">
+    <a href="https://modrinth.com/mod/flightassistant-unofficial">
         <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/cozy/available/modrinth_vector.svg"
             alt="Available on Modrinth"></a>
     <a href="https://modrinth.com/mod/fabric-api/">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,17 +45,17 @@ tasks.withType<Jar> {
 }
 
 modstitch {
-    minecraftVersion = minecraft
+    minecraftVersion = if (project.name == "26.2-fabric") "1.21.11" else minecraft
 
     val j21: Boolean = stonecutter.eval(minecraft, ">=1.20.6")
-    javaVersion = if (j21) 21 else 17
+    javaVersion = if (project.name == "26.2-fabric") 25 else if (j21) 21 else 17
 
     java {
         withSourcesJar()
     }
 
     kotlin {
-        jvmToolchain(if (j21) 21 else 17)
+        jvmToolchain(if (project.name == "26.2-fabric") 25 else if (j21) 21 else 17)
     }
 
     // If parchment doesnt exist for a version yet you can safely
@@ -94,7 +94,7 @@ modstitch {
         configureLoom {
             @Suppress("UnstableApiUsage")
             mixin {
-                useLegacyMixinAp = false
+                useLegacyMixinAp = true
             }
 
             runConfigs.all {
@@ -140,7 +140,18 @@ modstitch {
 // Wondering where the "repositories" block is? Go to "stonecutter.gradle.kts"
 // If you want to create proxy configurations for more source sets, such as client source sets,
 // use the modstitch.createProxyConfigurations(sourceSets["client"]) function.
+tasks.withType<net.fabricmc.loom.task.RemapJarTask>().configureEach {
+    classpath = classpath.filter { !it.name.contains("minecraft-26.2") }
+    if (project.name == "26.2-fabric") {
+        targetNamespace.set("named")
+    }
+}
+
 dependencies {
+    if (project.name == "26.2-fabric") {
+        compileOnly(files("C:/Users/Henrik/AppData/Roaming/PrismLauncher/libraries/com/mojang/minecraft/26.2/minecraft-26.2-client.jar"))
+    }
+
     modstitchImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 
     modstitch.loom {
@@ -179,8 +190,12 @@ publishMods {
     val curseforgeToken = findProperty("curseforgeToken")
     dryRun = modrinthToken == null || curseforgeToken == null
 
-    modstitch.onEnable {
-        file = modstitch.finalJarTask.flatMap { it.archiveFile }
+    if (project.name != "26.2-fabric") {
+        modstitch.onEnable {
+            file = modstitch.finalJarTask.flatMap { it.archiveFile }
+        }
+    } else {
+        file = tasks.named<org.gradle.api.tasks.bundling.AbstractArchiveTask>("remapJar").flatMap { it.archiveFile }
     }
     additionalFiles.from(tasks.named<Jar>("sourcesJar").flatMap { it.archiveFile })
 
@@ -225,7 +240,11 @@ publishMods {
 
 val buildAndCollect = tasks.register<Copy>("buildAndCollect") {
     group = "build"
-    from(modstitch.finalJarTask.get().archiveFile)
+    if (project.name != "26.2-fabric") {
+        from(modstitch.finalJarTask.get().archiveFile)
+    } else {
+        from(tasks.named<org.gradle.api.tasks.bundling.AbstractArchiveTask>("remapJar").get().archiveFile)
+    }
     into(rootProject.layout.buildDirectory.file("libs/${project.property("mod.version")}"))
     dependsOn("build")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ deps.flk=1.13.0
 
 publish.modrinth=CWqLEOPt
 publish.curseforge=972881
+
+kotlin.jvm.target.validation.mode=ignore

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ stonecutter {
         mc("1.21.6", "fabric")
         mc("1.21.9", "fabric")
         mc("1.21.11", "fabric")
+        mc("26.2", "fabric")
     }
 }
 

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinNew.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinNew.java
@@ -1,15 +1,24 @@
 package ru.octol1ttle.flightassistant.mixin.gui;
 
-import net.minecraft.client.gui.Gui;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Mixin(Gui.class)
-abstract class GuiMixinNew {
 //? if fabric && >=1.21.6 {
-    /*@org.spongepowered.asm.mixin.injection.Inject(method = "render", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;renderHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V"))
+//? if <26.2 {
+@Mixin(net.minecraft.client.gui.Gui.class)
+abstract class GuiMixinNew {
+    @org.spongepowered.asm.mixin.injection.Inject(method = "render", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;renderHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V"))
     private void beforeRenderHotbarAndDecorations(net.minecraft.client.gui.GuiGraphics guiGraphics, net.minecraft.client.DeltaTracker deltaTracker, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
         ru.octol1ttle.flightassistant.api.util.event.FixedGuiRenderCallback.EVENT.invoker().onRenderGui(guiGraphics, deltaTracker.getGameTimeDeltaPartialTick(true));
         guiGraphics.nextStratum();
     }
-*///?}
 }
+//?} else {
+@Mixin(net.minecraft.client.gui.Hud.class)
+abstract class GuiMixinNew {
+    @org.spongepowered.asm.mixin.injection.Inject(method = "extractRenderState", at = @org.spongepowered.asm.mixin.injection.At("TAIL"))
+    private void afterExtractRenderState(net.minecraft.client.gui.GuiGraphicsExtractor guiGraphics, net.minecraft.client.DeltaTracker deltaTracker, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        ru.octol1ttle.flightassistant.api.util.event.FixedGuiRenderCallback.EVENT.invoker().onRenderGui(guiGraphics, deltaTracker.getGameTimeDeltaPartialTick(true));
+    }
+}
+//?}
+//?}

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/level_renderer/LevelRendererMixinNewestest.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/level_renderer/LevelRendererMixinNewestest.java
@@ -5,7 +5,12 @@ import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(LevelRenderer.class)
 abstract class LevelRendererMixinNewestest {
-//? if >=1.21.9 {
+//? if >=26.2 {
+    @org.spongepowered.asm.mixin.injection.Inject(method = "render", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
+    private void onStartRender(com.mojang.blaze3d.resource.GraphicsResourceAllocator graphicsResourceAllocator, net.minecraft.client.DeltaTracker deltaTracker, boolean renderBlockOutline, net.minecraft.client.renderer.state.level.CameraRenderState cameraState, org.joml.Matrix4fc frustumMatrix, com.mojang.blaze3d.buffers.GpuBufferSlice fogBuffer, org.joml.Vector4f fogColor, boolean renderSky, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        ru.octol1ttle.flightassistant.api.util.event.LevelRenderCallback.EVENT.invoker().onStartRenderLevel(deltaTracker.getGameTimeDeltaPartialTick(true), net.minecraft.client.Minecraft.getInstance().gameRenderer.mainCamera(), cameraState.projectionMatrix, frustumMatrix.get3x3(new org.joml.Matrix3f()));
+    }
+//?} else if >=1.21.9 {
     /*@org.spongepowered.asm.mixin.injection.Inject(method = "renderLevel", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
     private void onStartRender(com.mojang.blaze3d.resource.GraphicsResourceAllocator graphicsResourceAllocator, net.minecraft.client.DeltaTracker deltaTracker, boolean renderBlockOutline, net.minecraft.client.Camera camera, org.joml.Matrix4f frustumMatrix, org.joml.Matrix4f projectionMatrix, org.joml.Matrix4f cullingProjectionMatrix, com.mojang.blaze3d.buffers.GpuBufferSlice fogBuffer, org.joml.Vector4f fogColor, boolean renderSky, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
         ru.octol1ttle.flightassistant.api.util.event.LevelRenderCallback.EVENT.invoker().onStartRenderLevel(deltaTracker.getGameTimeDeltaPartialTick(true), camera, projectionMatrix, frustumMatrix.get3x3(new org.joml.Matrix3f()));

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant
 
 import com.mojang.blaze3d.platform.InputConstants
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.KeyMapping
 import org.lwjgl.glfw.GLFW
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
@@ -68,7 +69,7 @@ object FAKeyMappings {
 
         while (openFlightAssistantSetup.consumeClick()) {
             mc.execute {
-                mc.setScreen(FlightAssistantSetupScreen())
+                mc.setScreenSafe(FlightAssistantSetupScreen())
             }
         }
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistant.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistant.kt
@@ -45,23 +45,23 @@ object FlightAssistant {
             ComputerHost.sendRegistrationEvent()
             initComplete = true
         }
-        LevelRenderCallback.EVENT.register { partialTick, camera, projectionMatrix, frustumMatrix ->
-            FAKeyMappings.checkPressed(ComputerHost)
+        LevelRenderCallback.EVENT.register { _, camera, projectionMatrix, frustumMatrix ->
+            synchronized(RenderMatrices) {
+                RenderMatrices.projectionMatrix.set(projectionMatrix)
+                RenderMatrices.worldSpaceMatrix.set(frustumMatrix)
+                // RenderMatrices.modelViewMatrix.set(RenderSystem.getModelViewMatrix())
 
-            ComputerHost.tick(partialTick)
+                RenderMatrices.worldSpaceNoRollMatrix.set(Matrix4f().apply {
+                    rotate(Axis.XP.rotationDegrees(camera.xRot))
+                    rotate(Axis.YP.rotationDegrees(camera.yRot + 180.0f))
+                })
 
-            RenderMatrices.projectionMatrix.set(projectionMatrix)
-            RenderMatrices.worldSpaceMatrix.set(frustumMatrix)
-            RenderMatrices.modelViewMatrix.set(RenderSystem.getModelViewMatrix())
-
-            RenderMatrices.worldSpaceNoRollMatrix.set(Matrix4f().apply {
-                rotate(Axis.XP.rotationDegrees(camera.xRot))
-                rotate(Axis.YP.rotationDegrees(camera.yRot + 180.0f))
-            })
-
-            RenderMatrices.ready = true
+                RenderMatrices.ready = true
+            }
         }
-        FixedGuiRenderCallback.EVENT.register { context, _ ->
+        FixedGuiRenderCallback.EVENT.register { context, partialTick ->
+            FAKeyMappings.checkPressed(ComputerHost)
+            ComputerHost.tick(partialTick)
             HudDisplayHost.render(context)
         }
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistantForge.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistantForge.kt
@@ -3,7 +3,8 @@ package ru.octol1ttle.flightassistant
 //? if !fabric {
 
 /*//? if neoforge {
-/^import net.minecraft.client.Minecraft
+/^import ru.octol1ttle.flightassistant.api.util.extensions.*
+import net.minecraft.client.Minecraft
 import net.neoforged.bus.api.IEventBus
 import net.neoforged.fml.ModLoadingContext
 import net.neoforged.fml.common.Mod

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/ModuleController.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/ModuleController.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 
 interface ModuleController<T> : ModuleView<T> {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/ModuleView.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/ModuleView.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 
 interface ModuleView<T> {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/AlertCategory.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/AlertCategory.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.alert
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.FlightAssistant
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/AlertData.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/AlertData.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.alert
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.sounds.SoundEvent
 import ru.octol1ttle.flightassistant.FlightAssistant
 import ru.octol1ttle.flightassistant.config.FAConfig

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/CenteredAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/CenteredAlert.kt
@@ -1,10 +1,12 @@
 package ru.octol1ttle.flightassistant.api.alert
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 
 interface CenteredAlert {
     /**
      * @return whether or not this alert has rendered and occupied the center of the screen
      */
-    fun render(guiGraphics: GuiGraphics, y: Int): Boolean
+    fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/ECAMAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/alert/ECAMAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.api.alert
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 
 interface ECAMAlert {
@@ -10,5 +12,5 @@ interface ECAMAlert {
      * @param otherLinesX The X coordinate value that should be used for the second line and onwards.
      * @return the amount of lines rendered
      */
-    fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int
+    fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/autoflight/ControlInput.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/autoflight/ControlInput.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.autoflight
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 
 /**

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/computer/ComputerRegistrationCallback.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/computer/ComputerRegistrationCallback.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.api.computer
 import dev.architectury.event.Event
 import dev.architectury.event.EventFactory
 import java.util.function.BiConsumer
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 
 fun interface ComputerRegistrationCallback {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/Display.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/Display.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.api.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
 
 // TODO: displays should also be allowed to have state. adjust the comment below too
@@ -17,6 +18,6 @@ abstract class Display(val computers: ComputerBus) {
         internal set
 
     abstract fun allowedByConfig(): Boolean
-    abstract fun render(guiGraphics: GuiGraphics)
-    abstract fun renderFaulted(guiGraphics: GuiGraphics)
+    abstract fun render(guiGraphics: FAGuiGraphics)
+    abstract fun renderFaulted(guiGraphics: FAGuiGraphics)
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/HudDisplayRegistrationCallback.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/HudDisplayRegistrationCallback.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.api.display
 import dev.architectury.event.Event
 import dev.architectury.event.EventFactory
 import java.util.function.BiConsumer
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/HudFrame.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/display/HudFrame.kt
@@ -2,7 +2,8 @@ package ru.octol1ttle.flightassistant.api.display
 
 import com.mojang.blaze3d.platform.Window
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
 import ru.octol1ttle.flightassistant.config.FAConfig
 
@@ -44,7 +45,7 @@ object HudFrame {
         right = rightF.toInt()
     }
 
-    fun scissor(guiGraphics: GuiGraphics) {
+    fun scissor(guiGraphics: FAGuiGraphics) {
         guiGraphics.enableScissor(left, top, right, bottom + 1)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/FATickCounter.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/FATickCounter.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.api.util
 
 import kotlin.random.Random
 import kotlin.random.nextInt
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.SharedConstants
 import net.minecraft.Util
 import net.minecraft.client.player.LocalPlayer

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/FloatLerper.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/FloatLerper.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.SharedConstants
 import net.minecraft.util.Mth
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/ScreenSpace.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/ScreenSpace.kt
@@ -12,7 +12,10 @@ object ScreenSpace {
     private var viewport: IntArray = IntArray(4)
 
     internal fun updateViewport() {
-        GL11.glGetIntegerv(GL11.GL_VIEWPORT, viewport)
+        viewport[0] = 0
+        viewport[1] = 0
+        viewport[2] = mc.window.width
+        viewport[3] = mc.window.height
     }
 
     /**
@@ -43,19 +46,26 @@ object ScreenSpace {
         val displayHeight: Int = mc.window.height
         val target = Vector3f()
 
+        var projMatrix: Matrix4f
+        var worldMatrix: Matrix4f
+        synchronized(RenderMatrices) {
+            projMatrix = Matrix4f(RenderMatrices.projectionMatrix)
+            worldMatrix = Matrix4f(if (useNoRollMatrix) RenderMatrices.worldSpaceNoRollMatrix else RenderMatrices.worldSpaceMatrix)
+        }
+
         val transformedCoordinates: Vector4f =
             Vector4f(deltaPos.x.toFloat(), deltaPos.y.toFloat(), deltaPos.z.toFloat(), 1f).mul(
-                if (useNoRollMatrix) RenderMatrices.worldSpaceNoRollMatrix else RenderMatrices.worldSpaceMatrix
+                worldMatrix
             )
+            
+        if (transformedCoordinates.z > 0.0f) {
+            return Vector3f(0f, 0f, -10f) // Behind camera, will fail isVisible
+        }
 
-        val matrixProj = Matrix4f(RenderMatrices.projectionMatrix)
-        val matrixModel = Matrix4f(RenderMatrices.modelViewMatrix)
-
-        matrixProj.mul(matrixModel)
-            .project(
-                transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), viewport,
-                target
-            )
+        projMatrix.project(
+            transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), viewport,
+            target
+        )
 
         return Vector3f(
             target.x / mc.window.guiScale.toFloat(),
@@ -74,7 +84,7 @@ object ScreenSpace {
         if (pos == null) {
             return false
         }
-        return pos.x >= 0 && pos.x <= mc.window.guiScaledWidth && pos.y >= 0 && pos.y <= mc.window.guiScaledHeight && pos.z > -1 && pos.z < 1
+        return pos.x >= -2000 && pos.x <= mc.window.guiScaledWidth + 2000 && pos.y >= -2000 && pos.y <= mc.window.guiScaledHeight + 2000 && pos.z > -1 && pos.z < 1
     }
 
     fun getX(heading: Float): Int? {
@@ -92,7 +102,7 @@ object ScreenSpace {
     *///?}
 
     fun getY(pitch: Float): Int? {
-        val vec: Vector3f = fromWorldSpace(Vec3.directionFromRotation(-pitch, mc.entityRenderDispatcher.camera!!.yRot), true)
+        val vec: Vector3f = fromWorldSpace(Vec3.directionFromRotation(-pitch, mc.gameRenderer.mainCamera().yRot), true)
         if (!isVisible(vec)) {
             return null
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/FireworkBoostCallback.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/FireworkBoostCallback.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.api.util.event
 
 import dev.architectury.event.Event
 import dev.architectury.event.EventFactory
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.world.entity.projectile.FireworkRocketEntity
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/FixedGuiRenderCallback.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/FixedGuiRenderCallback.kt
@@ -2,13 +2,14 @@ package ru.octol1ttle.flightassistant.api.util.event
 
 import dev.architectury.event.Event
 import dev.architectury.event.EventFactory
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 
 fun interface FixedGuiRenderCallback {
     /**
      * Called when the main HUD is being rendered.
      */
-    fun onRenderGui(context: GuiGraphics, partialTick: Float)
+    fun onRenderGui(context: FAGuiGraphics, partialTick: Float)
 
     companion object {
         @JvmField

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/LevelRenderCallback.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/event/LevelRenderCallback.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.api.util.event
 
 import dev.architectury.event.Event
 import dev.architectury.event.EventFactory
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.Camera
 import org.joml.Matrix3f
 import org.joml.Matrix4f

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/BlockStateExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/BlockStateExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.level.block.state.BlockState
 import ru.octol1ttle.flightassistant.mixin.EntityInvoker

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/ClientPlayerExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/ClientPlayerExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.player.AbstractClientPlayer
 import net.minecraft.world.phys.Vec3
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsExtensions.kt
@@ -5,6 +5,7 @@ import java.awt.Color
 import kotlin.math.max
 import net.minecraft.ChatFormatting
 import net.minecraft.client.gui.Font
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.FormattedText
@@ -16,19 +17,19 @@ internal val font: Font = mc.font
 val lineHeight: Int
     get() = font.lineHeight
 
-val GuiGraphics.halfWidth: Float
+val FAGuiGraphics.halfWidth: Float
     get() = guiWidth() * 0.5f
 
-val GuiGraphics.centerXF: Float
+val FAGuiGraphics.centerXF: Float
     get() = halfWidth
 
-val GuiGraphics.centerX: Int
+val FAGuiGraphics.centerX: Int
     get() = centerXF.toInt()
 
-val GuiGraphics.centerYF: Float
+val FAGuiGraphics.centerYF: Float
     get() = guiHeight() * 0.5f
 
-val GuiGraphics.centerY: Int
+val FAGuiGraphics.centerY: Int
     get() = centerYF.toInt()
 
 const val emptyColor: Int = 0
@@ -56,12 +57,12 @@ val warningColor: Int
 /**
  * Translates this graphics' pose and then scales it.
  */
-fun GuiGraphics.fusedTranslateScale(x: Float, y: Float, scale: Float) {
+fun FAGuiGraphics.fusedTranslateScale(x: Float, y: Float, scale: Float) {
     pose().translate(x, y /*? if <1.21.6 {*/, 0.0f /*?}*/)
     pose().scale(scale, scale /*? if <1.21.6 {*/, 1.0f /*?}*/)
 }
 
-fun GuiGraphics.hLineDashed(
+fun FAGuiGraphics.hLineDashed(
     x1: Int, x2: Int, y: Int,
     dashCount: Int, color: Int
 ) {
@@ -87,24 +88,40 @@ fun textWidth(text: String): Int {
     return font.width(text)
 }
 
-fun GuiGraphics.drawString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+fun FAGuiGraphics.drawString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+//? if <26.2 {
     drawString(font, text, x, y, color, shadow)
+//?} else {
+  this.text(font, text, x, y, color, shadow)
+//?}
 }
 
-fun GuiGraphics.drawRightAlignedString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+fun FAGuiGraphics.drawRightAlignedString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+//? if <26.2 {
     drawString(font, text, x - font.width(text), y, color, shadow)
+//?} else {
+  this.text(font, text, x - font.width(text), y, color, shadow)
+//?}
 }
 
-fun GuiGraphics.drawMiddleAlignedString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+fun FAGuiGraphics.drawMiddleAlignedString(text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+//? if <26.2 {
     drawString(font, text, x - font.width(text) / 2 + 1, y, color, shadow)
+//?} else {
+  this.text(font, text, x - font.width(text) / 2 + 1, y, color, shadow)
+//?}
 }
 
 fun textWidth(formattedText: FormattedText): Int {
     return font.width(formattedText)
 }
 
-fun GuiGraphics.drawString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false): Int {
+fun FAGuiGraphics.drawString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false): Int {
+//? if <26.2 {
     drawString(font, text, x, y, color, shadow)
+//?} else {
+  this.text(font, text, x, y, color, shadow)
+//?}
     return 1
 }
 
@@ -116,16 +133,24 @@ private fun getContrasting(original: Int): Int {
     return if (luma > 0.5) Color.BLACK.rgb else Color.WHITE.rgb
 }
 
-fun GuiGraphics.drawRightAlignedString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+fun FAGuiGraphics.drawRightAlignedString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+//? if <26.2 {
     drawString(font, text, x - textWidth(text), y, color, shadow)
+//?} else {
+  this.text(font, text, x - textWidth(text), y, color, shadow)
+//?}
 }
 
-fun GuiGraphics.drawMiddleAlignedString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+fun FAGuiGraphics.drawMiddleAlignedString(text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+//? if <26.2 {
     drawString(font, text, x - textWidth(text) / 2 + 1, y, color, shadow)
+//?} else {
+  this.text(font, text, x - textWidth(text) / 2 + 1, y, color, shadow)
+//?}
 }
 
-fun GuiGraphics.drawHighlightedCenteredText(text: Component, x: Int, y: Int, color: Int, highlight: Boolean, shadow: Boolean = false) {
-    pose().push()
+fun FAGuiGraphics.drawHighlightedCenteredText(text: Component, x: Int, y: Int, color: Int, highlight: Boolean, shadow: Boolean = false) {
+    pushPose()
 
     if (highlight) {
         val halfWidth: Int = textWidth(text) / 2
@@ -137,27 +162,21 @@ fun GuiGraphics.drawHighlightedCenteredText(text: Component, x: Int, y: Int, col
         drawMiddleAlignedString(text, x, y, color, shadow)
     }
 
-    pose().pop()
-}
-
-fun PoseStack.push() {
-    pushPose()
-}
-
-fun PoseStack.pop() {
     popPose()
 }
+
+
+
+
 
 fun org.joml.Matrix3x2fStack.push() {
     pushMatrix()
 }
 
-fun org.joml.Matrix3x2fStack.pop() {
-    popMatrix()
-}
 
+//? if <26.2 {
 //? if >=1.21.9 {
-/*fun GuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
+/*fun FAGuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
 //? if >=1.21.11 {
     /^renderOutline(
 ^///?} else
@@ -166,3 +185,90 @@ fun org.joml.Matrix3x2fStack.pop() {
     renderDeferredElements()
 }
 *///?}
+//?}
+
+
+//? if >=26.2 {
+fun FAGuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
+    fill(x, y, x + width, y + 1, color)
+    fill(x, y + height - 1, x + width, y + height, color)
+    fill(x, y + 1, x + 1, y + height - 1, color)
+    fill(x + width - 1, y + 1, x + width, y + height - 1, color)
+}
+//?}
+
+
+
+
+
+//? if >=26.2 {
+fun FAGuiGraphics.hLine(minX: Int, maxX: Int, y: Int, color: Int) {
+    var minXVar = minX
+    var maxXVar = maxX
+    if (minX > maxX) {
+        minXVar = maxX
+        maxXVar = minX
+    }
+    fill(minXVar, y, maxXVar + 1, y + 1, color)
+}
+
+fun FAGuiGraphics.vLine(x: Int, minY: Int, maxY: Int, color: Int) {
+    var minYVar = minY
+    var maxYVar = maxY
+    if (minY > maxY) {
+        minYVar = maxY
+        maxYVar = minY
+    }
+    fill(x, minYVar, x + 1, maxYVar + 1, color)
+}
+
+val net.minecraft.ChatFormatting.color: Int?
+    get() = net.minecraft.network.chat.TextColor.fromLegacyFormat(this)?.value
+//?}
+
+@Suppress("UNCHECKED_CAST")
+fun <T> castToPlatformType(obj: Any?): T = obj as T
+
+fun net.minecraft.client.Minecraft.setScreenSafe(screen: net.minecraft.client.gui.screens.Screen?) {
+//? if <26.2 {
+    this.setScreen(screen)
+//?} else {
+    this.setScreenAndShow(castToPlatformType(screen))
+//?}
+}
+
+//? if >=26.2 {
+fun net.minecraft.client.gui.components.AbstractWidget.renderCompat(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+    this.extractRenderState(guiGraphics, mouseX, mouseY, partialTick)
+}
+//?} else {
+fun net.minecraft.client.gui.components.AbstractWidget.renderCompat(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+    this.render(guiGraphics, mouseX, mouseY, partialTick)
+}
+//?}
+
+//? if >=26.2 {
+fun net.minecraft.client.gui.GuiGraphicsExtractor.drawString(font: net.minecraft.client.gui.Font, text: net.minecraft.network.chat.Component, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+    this.text(font, text, x, y, color, shadow)
+}
+
+fun net.minecraft.client.gui.GuiGraphicsExtractor.drawString(font: net.minecraft.client.gui.Font, text: String, x: Int, y: Int, color: Int, shadow: Boolean = false) {
+    this.text(font, text, x, y, color, shadow)
+}
+//?}
+
+fun FAGuiGraphics.pushPose() {
+//? if <26.2 {
+    this.pose().pushPose()
+//?} else {
+    this.pose().pushMatrix()
+//?}
+}
+
+fun FAGuiGraphics.popPose() {
+//? if <26.2 {
+    this.pose().popPose()
+//?} else {
+    this.pose().popMatrix()
+//?}
+}

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/LevelExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/LevelExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.world.level.Level
 
 val Level.bottomY: Int

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/MutableComponentExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/MutableComponentExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Style

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/SoundManagerExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/SoundManagerExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.resources.sounds.SoundInstance
 import net.minecraft.client.sounds.SoundManager
 import ru.octol1ttle.flightassistant.api.util.SoundExtensions

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/VectorExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/VectorExtensions.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.api.util.extensions
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.SharedConstants
 import net.minecraft.world.phys.Vec3
 import org.joml.Vector2d

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAConfig.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAConfig.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder
 import dev.isxander.yacl3.platform.YACLPlatform
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.player.LocalPlayer
 import ru.octol1ttle.flightassistant.FlightAssistant.MOD_ID
 import ru.octol1ttle.flightassistant.FlightAssistant.id

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAConfigScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAConfigScreen.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.config
 
 import dev.isxander.yacl3.api.ConfigCategory
 import dev.isxander.yacl3.dsl.*
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.FlightAssistant

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAModMenuIntegration.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/config/FAModMenuIntegration.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.config
 //? if fabric {
 import com.terraformersmc.modmenu.api.ConfigScreenFactory
 import com.terraformersmc.modmenu.api.ModMenuApi
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.screens.Screen
 
 object FAModMenuIntegration : ModMenuApi {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/config/options/DisplayOptions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/config/options/DisplayOptions.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.config.options
 import dev.isxander.yacl3.api.NameableEnum
 import dev.isxander.yacl3.config.v2.api.SerialEntry
 import java.awt.Color
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 
 class DisplayOptions {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/config/options/SafetyOptions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/config/options/SafetyOptions.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.config.options
 
 import dev.isxander.yacl3.api.NameableEnum
 import dev.isxander.yacl3.config.v2.api.SerialEntry
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 
 class SafetyOptions {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/AlertSoundInstance.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/AlertSoundInstance.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.impl.alert
 
 import kotlin.math.max
 import kotlin.math.min
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.resources.sounds.AbstractSoundInstance
 import net.minecraft.client.resources.sounds.SoundInstance
 import net.minecraft.client.sounds.SoundManager

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/autoflight/AutoThrustOffAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/autoflight/AutoThrustOffAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.autoflight
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -21,7 +23,7 @@ class AutoThrustOffAlert(computers: ComputerBus) : Alert(computers), ECAMAlert {
         computers.autoflight.autoThrustAlert = false
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.autoflight.auto_thrust_off"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/autoflight/AutopilotOffAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/autoflight/AutopilotOffAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.autoflight
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -39,7 +41,7 @@ class AutopilotOffAlert(computers: ComputerBus) : Alert(computers), ECAMAlert {
         computers.autoflight.autopilotAlert = false
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i: Int = guiGraphics.drawString(Component.translatable("alert.flightassistant.autoflight.autopilot_off"), firstLineX, firstLineY, warningColor)
         if (computers.autoflight.autopilotAlert) {
             i += guiGraphics.drawString(Component.translatable("alert.flightassistant.autoflight.autopilot_off.push_to_silence"), otherLinesX, firstLineY + 11, primaryAdvisoryColor)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/elytra/ElytraDurabilityCriticalAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/elytra/ElytraDurabilityCriticalAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.elytra
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -21,7 +23,7 @@ class ElytraDurabilityCriticalAlert(computers: ComputerBus) : Alert(computers), 
         return remainingFlightTime < 30
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.elytra.critical_durability"), firstLineX, firstLineY, warningColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/elytra/ElytraDurabilityLowAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/elytra/ElytraDurabilityLowAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.elytra
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -22,7 +24,7 @@ class ElytraDurabilityLowAlert(computers: ComputerBus) : Alert(computers), ECAMA
         return remainingFlightTime in 30..<90
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.elytra.low_durability"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/DisplayFaultAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/DisplayFaultAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.fault
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
@@ -20,7 +22,7 @@ class DisplayFaultAlert(computers: ComputerBus, val identifier: ResourceLocation
         return HudDisplayHost.isFaulted(identifier)
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i = 0
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.fault.hud.$identifier"), firstLineX, firstLineY, cautionColor)
         i +=

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/computer/AlertComputerFaultAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/computer/AlertComputerFaultAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.fault.computer
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class AlertComputerFaultAlert(computers: ComputerBus) : Alert(computers), ECAMAl
         return computers.alert.alertsFaulted
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.alert.fault"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/computer/ComputerFaultAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/fault/computer/ComputerFaultAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.fault.computer
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
@@ -24,7 +26,7 @@ class ComputerFaultAlert(
         return ComputerHost.isFaulted(identifier)
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         val color: Int = data.colorSupplier.invoke()
         var i = 0
         i += guiGraphics.drawString(alertText, firstLineX, firstLineY, color)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkExplosiveAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkExplosiveAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.firework
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.world.InteractionHand
@@ -19,7 +21,7 @@ class FireworkExplosiveAlert(computers: ComputerBus, private val hand: Interacti
         return FAConfig.safety.fireworkExplosiveAlert && !computers.firework.isEmptyOrSafe(computers.data.player, hand)
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.firework.explosive.${hand.toString().lowercase()}"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkNoResponseAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkNoResponseAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.firework
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class FireworkNoResponseAlert(computers: ComputerBus) : Alert(computers), ECAMAl
         return computers.firework.waitingForResponse && FATickCounter.totalTicks - computers.firework.lastActivationTime >= 30
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.firework.no_response"), firstLineX, firstLineY, warningColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkSlowResponseAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/firework/FireworkSlowResponseAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.firework
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class FireworkSlowResponseAlert(computers: ComputerBus) : Alert(computers), ECAM
         return computers.firework.responseTimes.average() >= 10
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.firework.slow_response"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_controls/ProtectionsLostAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_controls/ProtectionsLostAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.flight_controls
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -18,7 +20,7 @@ class ProtectionsLostAlert(computers: ComputerBus) : Alert(computers), ECAMAlert
         return computers.protections.isDisabledOrFaulted()
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i = 0
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.flight_controls.protections_lost"), firstLineX, firstLineY, cautionColor)
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/ArrivalElevationDisagreeAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/ArrivalElevationDisagreeAlert.kt
@@ -1,6 +1,8 @@
 package ru.octol1ttle.flightassistant.impl.alert.flight_plan
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.levelgen.Heightmap
@@ -29,7 +31,7 @@ class ArrivalElevationDisagreeAlert(computers: ComputerBus) : Alert(computers), 
         return abs(actualElevation - computers.plan.arrivalData.elevation) > 2
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i = 0
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.flight_plan.arrival_elevation_disagree"), firstLineX, firstLineY, cautionColor)
         var y = firstLineY + 1

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/DepartureElevationDisagreeAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/DepartureElevationDisagreeAlert.kt
@@ -1,6 +1,8 @@
 package ru.octol1ttle.flightassistant.impl.alert.flight_plan
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.levelgen.Heightmap
@@ -28,7 +30,7 @@ class DepartureElevationDisagreeAlert(computers: ComputerBus) : Alert(computers)
         return abs(actualElevation - computers.plan.departureData.elevation) > 2
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.flight_plan.departure_elevation_disagree"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/DescentTooSteepAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/DescentTooSteepAlert.kt
@@ -1,6 +1,8 @@
 package ru.octol1ttle.flightassistant.impl.alert.flight_plan
 
 import kotlin.math.asin
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -40,7 +42,7 @@ class DescentTooSteepAlert(computers: ComputerBus) : Alert(computers), ECAMAlert
         return false
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.flight_plan.descent_too_steep"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/ObstaclesOnPathAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/flight_plan/ObstaclesOnPathAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.flight_plan
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.world.level.ClipContext
@@ -52,7 +54,7 @@ class ObstaclesOnPathAlert(computers: ComputerBus) : Alert(computers), ECAMAlert
         return false
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.flight_plan.obstacles_on_path"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/BelowGlideSlopeAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/BelowGlideSlopeAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -30,7 +32,7 @@ class BelowGlideSlopeAlert(computers: ComputerBus) : Alert(computers), CenteredA
         return glideSlopeDeviation > 5.0
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.gpws.below_glide_slope"), guiGraphics.centerX, y, cautionColor, totalTicks % 40 >= 20)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/BelowGlideSlopeWarningAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/BelowGlideSlopeWarningAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -36,7 +38,7 @@ class BelowGlideSlopeWarningAlert(computers: ComputerBus) : Alert(computers), Ce
         return altitudeAboveGround < glideSlopeDeviation
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.gpws.below_glide_slope"), guiGraphics.centerX, y, warningColor, totalTicks % 20 >= 10)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/DontSinkAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/DontSinkAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -34,7 +36,7 @@ class DontSinkAlert(computers: ComputerBus) : Alert(computers), CenteredAlert {
         return age >= 20
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.gpws.dont_sink"), guiGraphics.centerX, y, cautionColor, totalTicks % 40 >= 20)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/MinimumsReachedAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/MinimumsReachedAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -29,7 +31,7 @@ class MinimumsReachedAlert(computers: ComputerBus) : Alert(computers), ECAMAlert
         return reached
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.gpws.minimums_reached"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/PullUpAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/PullUpAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -34,7 +36,7 @@ class PullUpAlert(computers: ComputerBus) : Alert(computers), CenteredAlert {
         }
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         val flash: Boolean =
             if (computers.gpws.groundImpactStatus == GroundProximityComputer.Status.RECOVER
                 || computers.gpws.obstacleImpactStatus == GroundProximityComputer.Status.RECOVER) totalTicks % 10 >= 5

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/SinkRateAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/SinkRateAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -25,7 +27,7 @@ class SinkRateAlert(computers: ComputerBus) : Alert(computers), CenteredAlert {
         return FAConfig.safety.sinkRateAlertMethod
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.gpws.sink_rate"), guiGraphics.centerX, y, cautionColor, totalTicks % 40 >= 20)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/TerrainAheadAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/gpws/TerrainAheadAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.gpws
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -25,7 +27,7 @@ class TerrainAheadAlert(computers: ComputerBus) : Alert(computers), CenteredAler
         return FAConfig.safety.obstacleAlertMethod
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.gpws.terrain_ahead"), guiGraphics.centerX, y, cautionColor, totalTicks % 40 >= 20)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/ApproachingVoidDamageAltitudeAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/ApproachingVoidDamageAltitudeAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.navigation
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -19,7 +21,7 @@ class ApproachingVoidDamageAltitudeAlert(computers: ComputerBus) : Alert(compute
         return FAConfig.safety.voidAlertMode.caution() && computers.voidProximity.status == VoidProximityComputer.Status.APPROACHING_DAMAGE_ALTITUDE
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.navigation.approaching_void_damage_altitude"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/NoChunksLoadedAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/NoChunksLoadedAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.navigation
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class NoChunksLoadedAlert(computers: ComputerBus) : Alert(computers), ECAMAlert 
         return computers.chunk.status == ChunkStatusComputer.Status.ALL_UNLOADED
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.navigation.no_chunks_loaded"), firstLineX, firstLineY, warningColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/ReachedVoidDamageAltitudeAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/ReachedVoidDamageAltitudeAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.navigation
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -18,7 +20,7 @@ class ReachedVoidDamageAltitudeAlert(computers: ComputerBus) : Alert(computers),
         return FAConfig.safety.voidAlertMode.warning() && computers.voidProximity.status == VoidProximityComputer.Status.REACHED_DAMAGE_ALTITUDE
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.navigation.reached_void_damage_altitude"), firstLineX, firstLineY, warningColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/SlowChunkLoadingAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/navigation/SlowChunkLoadingAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.navigation
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -30,7 +32,7 @@ class SlowChunkLoadingAlert(computers: ComputerBus) : Alert(computers), ECAMAler
         return shouldActivate
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.navigation.slow_chunk_loading"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/stall/ApproachingStallAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/stall/ApproachingStallAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.stall
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -25,7 +27,7 @@ class ApproachingStallAlert(computers: ComputerBus) : Alert(computers), Centered
         return FAConfig.safety.stallAlertMethod
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.stall"), guiGraphics.centerX, y, cautionColor, totalTicks % 40 >= 20)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/stall/FullStallAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/stall/FullStallAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.stall
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -25,7 +27,7 @@ class FullStallAlert(computers: ComputerBus) : Alert(computers), CenteredAlert {
         return FAConfig.safety.stallAlertMethod
     }
 
-    override fun render(guiGraphics: GuiGraphics, y: Int): Boolean {
+    override fun render(guiGraphics: FAGuiGraphics, y: Int): Boolean {
         guiGraphics.drawHighlightedCenteredText(Component.translatable("alert.flightassistant.stall"), guiGraphics.centerX, y, warningColor, totalTicks % 20 >= 10)
         return true
     }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/NoThrustSourceAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/NoThrustSourceAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.thrust
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class NoThrustSourceAlert(computers: ComputerBus) : Alert(computers), ECAMAlert 
         return computers.thrust.noThrustSource
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         return guiGraphics.drawString(Component.translatable("alert.flightassistant.thrust.no_source"), firstLineX, firstLineY, cautionColor)
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/ReverseThrustNotSupportedAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/ReverseThrustNotSupportedAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.thrust
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -18,7 +20,7 @@ class ReverseThrustNotSupportedAlert(computers: ComputerBus) : Alert(computers),
         return computers.thrust.reverseUnsupported
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i = 0
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.thrust.reverse_not_supported"), firstLineX, firstLineY, cautionColor)
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.thrust.reverse_not_supported.set_forward"), otherLinesX, firstLineY + 11, primaryAdvisoryColor)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/ThrustLockedAlert.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/alert/thrust/ThrustLockedAlert.kt
@@ -1,5 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.alert.thrust
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.alert.Alert
@@ -17,7 +19,7 @@ class ThrustLockedAlert(computers: ComputerBus) : Alert(computers), ECAMAlert {
         return computers.thrust.thrustLocked
     }
 
-    override fun render(guiGraphics: GuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
+    override fun render(guiGraphics: FAGuiGraphics, firstLineX: Int, otherLinesX: Int, firstLineY: Int): Int {
         var i = 0
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.thrust.locked"), firstLineX, firstLineY, cautionColor)
         i += guiGraphics.drawString(Component.translatable("alert.flightassistant.thrust.locked.use_keys"), otherLinesX, firstLineY + 11, primaryAdvisoryColor)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/ComputerHost.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/ComputerHost.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
 import ru.octol1ttle.flightassistant.FlightAssistant.mc

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/AutoFlightComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/AutoFlightComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FAKeyMappings

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FireworkComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FireworkComputer.kt
@@ -35,6 +35,24 @@ class FireworkComputer(computers: ComputerBus, private val mc: Minecraft) : Comp
 
     override fun subscribeToEvents() {
         ThrustSourceRegistrationCallback.EVENT.register { it.accept(this) }
+//? if fabric && >=26.2 {
+        net.fabricmc.fabric.api.event.player.UseItemCallback.EVENT.register { player, world, hand ->
+            val stack = player.getItemInHand(hand)
+            if (world.isClientSide() && computers.data.flying && stack.item is FireworkRocketItem) {
+                val explosive = FAConfig.safety.fireworkLockExplosive && !isEmptyOrSafe(player, hand)
+                val anyTerrainAhead = FAConfig.safety.fireworkLockObstacles && anyTerrainAhead()
+                if (computers.data.automationsAllowed() && (explosive || anyTerrainAhead)) {
+                    return@register net.minecraft.world.InteractionResult.FAIL
+                }
+
+                if (!waitingForResponse) {
+                    lastActivationTime = FATickCounter.totalTicks
+                    waitingForResponse = true
+                }
+            }
+            return@register net.minecraft.world.InteractionResult.PASS
+        }
+//?} else {
         InteractionEvent.RIGHT_CLICK_ITEM.register(InteractionEvent.RightClickItem { player, hand ->
             val stack: ItemStack = player.getItemInHand(hand)
             if (player.level().isClientSide() && computers.data.flying && stack.item is FireworkRocketItem) {
@@ -42,9 +60,10 @@ class FireworkComputer(computers: ComputerBus, private val mc: Minecraft) : Comp
                 val anyTerrainAhead = FAConfig.safety.fireworkLockObstacles && anyTerrainAhead()
                 if (computers.data.automationsAllowed() && (explosive || anyTerrainAhead)) {
 //? if >=1.21.2 {
-                    /*return@RightClickItem net.minecraft.world.InteractionResult.FAIL
-*///?} else
+                    /*return@RightClickItem dev.architectury.event.EventResult.interruptFalse()
+*///?} else {
                     return@RightClickItem dev.architectury.event.CompoundEventResult.interruptFalse(stack)
+//?}
                 }
 
                 if (!waitingForResponse) {
@@ -54,10 +73,12 @@ class FireworkComputer(computers: ComputerBus, private val mc: Minecraft) : Comp
             }
 
 //? if >=1.21.2 {
-            /*return@RightClickItem net.minecraft.world.InteractionResult.PASS
-*///?} else
+            /*return@RightClickItem dev.architectury.event.EventResult.pass()
+*///?} else {
             return@RightClickItem dev.architectury.event.CompoundEventResult.pass()
+//?}
         })
+//?}
         FireworkBoostCallback.EVENT.register(FireworkBoostCallback { _, _ ->
             if (waitingForResponse) {
                 waitingForResponse = false

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FlightPlanComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FlightPlanComputer.kt
@@ -7,6 +7,7 @@ import kotlin.math.abs
 import kotlin.math.roundToLong
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.SharedConstants
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
@@ -200,8 +201,12 @@ class FlightPlanComputer(computers: ComputerBus) : Computer(computers) {
     }
 
     fun getFormattedTime(distance: Double): String {
-        val duration: Duration = Duration.ofSeconds((distance / groundSpeeds.average()).roundToLong())
-        return if (computers.data.flying) "${duration.toMinutesPart()}:${"%02d".formatRoot(duration.toSecondsPart())}" else "--:--"
+        val average = groundSpeeds.average()
+        return if (computers.data.flying && average >= 5.0) {
+            val duration: Duration = Duration.ofSeconds((distance / average).roundToLong())
+            "${duration.toMinutesPart()}:${"%02d".formatRoot(duration.toSecondsPart())}"
+        } else
+            "--:--"
     }
 
     fun getThrustMode(): AutoFlightComputer.ThrustMode? {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/HeadingComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/HeadingComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.base
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.entity.player.Player
 import ru.octol1ttle.flightassistant.FlightAssistant

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/PitchComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/PitchComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.base
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.entity.player.Player
 import ru.octol1ttle.flightassistant.FlightAssistant

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/RollComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/RollComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.base
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
 import ru.octol1ttle.flightassistant.api.autoflight.ControlInput

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/ThrustComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/base/ThrustComputer.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.base
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FAKeyMappings

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInLateralModes.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInLateralModes.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.modes
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import org.joml.Vector2d
 import ru.octol1ttle.flightassistant.api.autoflight.ControlInput

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInThrustModes.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInThrustModes.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.impl.computer.autoflight.modes
 
 import kotlin.math.abs
 import kotlin.math.pow
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.SharedConstants
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.autoflight.ControlInput

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInVerticalModes.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/modes/BuiltInVerticalModes.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.autoflight.modes
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.util.Mth
 import org.joml.Vector2d

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.impl.computer.data
 import kotlin.math.asin
 import kotlin.math.atan2
 import kotlin.math.max
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.Minecraft
 import net.minecraft.client.multiplayer.ClientLevel
 import net.minecraft.client.player.LocalPlayer
@@ -87,7 +88,11 @@ class AirDataComputer(computers: ComputerBus, private val mc: Minecraft) : Compu
         if (FAKeyMappings.globalAutomationOverride.isDown) {
             return false
         }
+        //? if <26.2 {
         return (!checkFlying || flying) && (FAConfig.global.automationsAllowedInOverlays || (mc.screen == null && mc.overlay == null))
+//?} else {
+/*        return (!checkFlying || flying) && (FAConfig.global.automationsAllowedInOverlays || (mc.gui.screen() == null && mc.gui.overlay() == null))
+*///?}
     }
 
     fun isInvulnerableTo(source: DamageSource): Boolean {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/HudDisplayDataComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/HudDisplayDataComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.data
 
 import kotlin.math.atan2
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.Minecraft
 import net.minecraft.client.player.LocalPlayer
 import net.minecraft.resources.ResourceLocation

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/AlertComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/AlertComputer.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.safety
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.sounds.SoundManager
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/ChunkStatusComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/ChunkStatusComputer.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.computer.safety
 
 import kotlin.math.abs
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.multiplayer.ClientChunkCache
 import net.minecraft.core.SectionPos
 import net.minecraft.resources.ResourceLocation

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/ElytraStatusComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/ElytraStatusComputer.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.impl.computer.safety
 import java.time.Duration
 import kotlin.math.round
 import kotlin.math.roundToInt
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket
 import net.minecraft.resources.ResourceLocation

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/FlightProtectionsComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/FlightProtectionsComputer.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.safety
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
 import ru.octol1ttle.flightassistant.api.computer.Computer

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/GroundProximityComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/GroundProximityComputer.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.impl.computer.safety
 
 import kotlin.math.abs
 import kotlin.math.max
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.core.Direction
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/StallComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/StallComputer.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.safety
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/VoidProximityComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/safety/VoidProximityComputer.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.computer.safety
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AlertDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AlertDisplay.kt
@@ -1,6 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Style
@@ -23,7 +23,7 @@ class AlertDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showAlerts
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.left + 5
             var y: Int = HudFrame.top + 5
@@ -69,7 +69,7 @@ class AlertDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.left + 5
             val y: Int = HudFrame.top + 5

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AltitudeDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AltitudeDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.util.Mth
@@ -18,7 +18,7 @@ class AltitudeDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showAltitudeReading || FAConfig.display.showAltitudeScale
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             if (FAConfig.display.showAltitudeReading) {
                 renderAltitudeReading(HudFrame.rightF, centerYF)
@@ -32,8 +32,8 @@ class AltitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.renderAltitudeReading(x: Float, y: Float) {
-        pose().push()
+    private fun FAGuiGraphics.renderAltitudeReading(x: Float, y: Float) {
+        pushPose()
         fusedTranslateScale(x, y, READING_MATRIX_SCALE)
 
         val altitude: Double = computers.hudData.lerpedAltitude
@@ -46,10 +46,10 @@ class AltitudeDisplay(computers: ComputerBus) : Display(computers) {
         val textY: Int = -4
         drawString(text, 3, textY, primaryColor)
 
-        pose().pop()
+        popPose()
     }
 
-    private fun GuiGraphics.renderAltitudeScale(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderAltitudeScale(x: Int, y: Int) {
         val altitude: Double = computers.hudData.lerpedAltitude
 
         val minY: Int = HudFrame.top
@@ -94,20 +94,22 @@ class AltitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.drawAltitudeLine(x: Int, y: Int, altitude: Int, currentAltitude: Double): Boolean {
+    private fun FAGuiGraphics.drawAltitudeLine(x: Int, y: Int, altitude: Int, currentAltitude: Double): Boolean {
         val textY: Int = (y + 2 * (currentAltitude - altitude)).toInt()
         if (textY < HudFrame.top - 100 || textY > HudFrame.bottom + 100) {
             return false
         }
-        hLine(x + 5, x, textY, primaryColor)
-        if (altitude % 20 == 0) {
-            drawString(altitude.toString(), x + 8, textY - 3, primaryColor)
+        if (textY < y - 10 || textY > y + 10) {
+            hLine(x + 5, x, textY, primaryColor)
+            if (altitude % 20 == 0) {
+                drawString(altitude.toString(), x + 8, textY - 3, primaryColor)
+            }
         }
 
         return true
     }
 
-    private fun GuiGraphics.renderAltitudeTarget(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderAltitudeTarget(x: Int, y: Int) {
         val color: Int
         val active: AutoFlightComputer.VerticalMode? = computers.autoflight.activeVerticalMode
         if ((computers.autoflight.flightDirectors || computers.autoflight.autopilot) && active is AutoFlightComputer.FollowsAltitudeMode) {
@@ -116,7 +118,7 @@ class AltitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawString(Component.translatable("short.flightassistant.altitude"), HudFrame.right, centerY - 5, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AttitudeDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AttitudeDisplay.kt
@@ -2,7 +2,7 @@ package ru.octol1ttle.flightassistant.impl.display
 
 import com.mojang.math.Axis
 import kotlin.math.sign
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.util.Mth
@@ -27,7 +27,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showAttitude != DisplayOptions.AttitudeDisplayMode.DISABLED
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         if (computers.hudData.isViewMirrored) {
             return
         }
@@ -35,7 +35,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         with(guiGraphics) {
             val centerX: Float = centerXF - 0.5f
 
-            pose().push()
+            pushPose()
 //? if <1.21.6
             pose().translate(0.0f, 0.0f, -200.0f)
 //? if >=1.21.6 {
@@ -60,14 +60,14 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
                 disableScissor()
             }
 
-            pose().pop()
+            popPose()
             if (FAConfig.display.showAutomationModes) {
                 renderPitchTarget(this.centerX - 6, centerY - 10)
             }
         }
     }
 
-    private fun GuiGraphics.renderHorizon(centerX: Float) {
+    private fun FAGuiGraphics.renderHorizon(centerX: Float) {
         ScreenSpace.getY(0.0f)?.let {
             val color = getPitchBarColor(0.0f)
 
@@ -87,7 +87,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.renderPitchBars(centerX: Float) {
+    private fun FAGuiGraphics.renderPitchBars(centerX: Float) {
         val step: Int = FAConfig.display.attitudeDegreeStep
         val nextUp: Int = Mth.roundToward(computers.data.pitch.toInt(), step)
         for (i: Int in nextUp..90 step step) {
@@ -100,7 +100,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.renderPitchLimits(centerX: Float) {
+    private fun FAGuiGraphics.renderPitchLimits(centerX: Float) {
         val step: Int = FAConfig.display.attitudeDegreeStep / 2
 
         val arrowText: Component = Component.literal("V")
@@ -119,7 +119,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
         while (min >= -180) {
             val y: Int = ScreenSpace.getY(min) ?: break
-            pose().push()
+            pushPose()
 
             pose().translate(centerX, y.toFloat() /*? if <1.21.6 {*/, 0.0f /*?}*/) // Rotate around the middle of the arrow
 //? if >=1.21.6 {
@@ -128,12 +128,12 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
             pose().mulPose(Axis.ZN.rotationDegrees(180.0f)) // Flip upside down
             drawMiddleAlignedString(arrowText, 0, -9, if (minInput?.status == ControlInput.Status.ACTIVE) warningColor else cautionColor)
 
-            pose().pop()
+            popPose()
             min -= step
         }
     }
 
-    private fun GuiGraphics.drawPitchReferenceMark(pitch: Float, centerX: Float) {
+    private fun FAGuiGraphics.drawPitchReferenceMark(pitch: Float, centerX: Float) {
         val y = ScreenSpace.getY(pitch) ?: return
 
         val color: Int = getPitchBarColor(pitch)
@@ -150,7 +150,7 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
         hLineDashed(rightXStart, rightXEnd, y, 2, color)
     }
 
-    private fun GuiGraphics.drawPitchBar(pitch: Int, centerX: Float, y: Int) {
+    private fun FAGuiGraphics.drawPitchBar(pitch: Int, centerX: Float, y: Int) {
         if (pitch == 0) return
 
         val color: Int = getPitchBarColor(pitch.toFloat())
@@ -183,14 +183,14 @@ class AttitudeDisplay(computers: ComputerBus) : Display(computers) {
             primaryColor
     }
 
-    private fun GuiGraphics.renderPitchTarget(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderPitchTarget(x: Int, y: Int) {
         val active: AutoFlightComputer.VerticalMode? = computers.autoflight.activeVerticalMode
         if ((computers.autoflight.flightDirectors || computers.autoflight.autopilot) && active is AutoFlightComputer.FollowsPitchMode) {
             drawRightAlignedString("%.1f".formatRoot(active.targetPitch), x, y, primaryAdvisoryColor)
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawMiddleAlignedString(Component.translatable("short.flightassistant.attitude"), centerX, centerY - 16, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AutomationModesDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/AutomationModesDisplay.kt
@@ -2,7 +2,7 @@ package ru.octol1ttle.flightassistant.impl.display
 
 import java.util.Objects
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.resources.ResourceLocation
@@ -26,14 +26,14 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showAutomationModes
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         renderThrustMode(guiGraphics)
         renderPitchMode(guiGraphics)
         renderInput(guiGraphics, headingDisplay, computers.heading.activeInput)
         renderAutomaticsMode(guiGraphics)
     }
 
-    private fun renderThrustMode(guiGraphics: GuiGraphics) {
+    private fun renderThrustMode(guiGraphics: FAGuiGraphics) {
         val thrustUnusable: Boolean = computers.thrust.noThrustSource || computers.thrust.reverseUnsupported
 
         val input: ControlInput? = computers.thrust.activeInput
@@ -74,7 +74,7 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         thrustDisplay.render(guiGraphics, null, ControlInput.Status.ACTIVE)
     }
 
-    private fun renderPitchMode(guiGraphics: GuiGraphics) {
+    private fun renderPitchMode(guiGraphics: FAGuiGraphics) {
         if (FAKeyMappings.globalAutomationOverride.isDown) {
             pitchDisplay.render(guiGraphics, Component.translatable("mode.flightassistant.vertical.override").setColor(cautionColor), ControlInput.Status.ACTIVE, cautionColor)
             return
@@ -82,7 +82,7 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         renderInput(guiGraphics, pitchDisplay, computers.pitch.activeInput)
     }
 
-    private fun renderInput(guiGraphics: GuiGraphics, display: ModeDisplay, input: ControlInput?) {
+    private fun renderInput(guiGraphics: FAGuiGraphics, display: ModeDisplay, input: ControlInput?) {
         if (input != null) {
             display.render(guiGraphics, input.text, input.status, if (input.status == ControlInput.Status.ACTIVE && input.priority < ControlInput.Priority.NORMAL) cautionColor else null)
         } else {
@@ -90,7 +90,7 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun renderAutomaticsMode(guiGraphics: GuiGraphics) {
+    private fun renderAutomaticsMode(guiGraphics: FAGuiGraphics) {
         val text: MutableComponent = Component.empty()
         if (computers.autoflight.flightDirectors) {
             text.appendWithSeparation(Component.translatable("short.flightassistant.flight_directors_alt"))
@@ -113,7 +113,7 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         )
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = centerX
             val y: Int = HudFrame.top - 9
@@ -131,7 +131,7 @@ class AutomationModesDisplay(computers: ComputerBus) : Display(computers) {
         private var lastText: Component? = null
         private var textChangedAt: Int = 0
 
-        fun render(guiGraphics: GuiGraphics, text: Component?, status: ControlInput.Status = ControlInput.Status.ACTIVE, borderColor: Int? = null) {
+        fun render(guiGraphics: FAGuiGraphics, text: Component?, status: ControlInput.Status = ControlInput.Status.ACTIVE, borderColor: Int? = null) {
             val farLeft: Int = HudFrame.left + 1
             val farRight: Int = HudFrame.right - 1
             val farWidth: Int = farRight - farLeft

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/CoordinatesDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/CoordinatesDisplay.kt
@@ -1,6 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.util.Mth
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -16,7 +16,7 @@ class CoordinatesDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showCoordinates
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.left + 5
             val y: Int = HudFrame.bottom - 19
@@ -60,7 +60,7 @@ class CoordinatesDisplay(computers: ComputerBus) : Display(computers) {
         return ""
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.left + 10
             val y: Int = HudFrame.bottom - 19

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/CourseDeviationDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/CourseDeviationDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -16,14 +16,14 @@ class CourseDeviationDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showCourseDeviation
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             renderLateralDeviation()
             renderVerticalDeviation()
         }
     }
 
-    private fun GuiGraphics.renderLateralDeviation() {
+    private fun FAGuiGraphics.renderLateralDeviation() {
         val deviation = (computers.plan.getLateralDeviation(computers.hudData.lerpedPosition) ?: return).coerceIn(-22.5, 22.5)
         val pixelsPerBlock = 2
 
@@ -34,7 +34,7 @@ class CourseDeviationDisplay(computers: ComputerBus) : Display(computers) {
         renderOutline((centerX - deviation * pixelsPerBlock - 4).roundToInt(), HudFrame.bottom - 11, 9, 9, secondaryAdvisoryColor)
     }
 
-    private fun GuiGraphics.renderVerticalDeviation() {
+    private fun FAGuiGraphics.renderVerticalDeviation() {
         val deviation = (computers.plan.getVerticalDeviation(computers.hudData.lerpedPosition) ?: return).coerceIn(-11.25, 11.25)
         val pixelsPerBlock = 4
 
@@ -45,7 +45,7 @@ class CourseDeviationDisplay(computers: ComputerBus) : Display(computers) {
         renderOutline(HudFrame.right - 17, (centerY - deviation * pixelsPerBlock - 5).roundToInt(), 9, 9, secondaryAdvisoryColor)
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawMiddleAlignedString(Component.translatable("short.flightassistant.lateral_deviation"), centerX, HudFrame.bottom - 10, warningColor)
             drawRightAlignedString(Component.translatable("short.flightassistant.vertical_deviation"), HudFrame.right - 10, centerY - 5, warningColor)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/ElytraDurabilityDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/ElytraDurabilityDisplay.kt
@@ -1,6 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -15,7 +15,7 @@ class ElytraDurabilityDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showElytraDurability
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = (HudFrame.left + (HudFrame.width - HudFrame.height) * 0.25f).toInt()
             val y: Int = HudFrame.bottom + 1
@@ -37,7 +37,7 @@ class ElytraDurabilityDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = (HudFrame.left + (HudFrame.width - HudFrame.height) * 0.25f).toInt()
             val y: Int = HudFrame.bottom + 1

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/FlightDirectorsDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/FlightDirectorsDisplay.kt
@@ -2,7 +2,7 @@ package ru.octol1ttle.flightassistant.impl.display
 
 import com.mojang.math.Axis
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -24,7 +24,7 @@ class FlightDirectorsDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showFlightDirectors
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         if (!computers.autoflight.flightDirectors || computers.hudData.isViewMirrored) {
             return
         }
@@ -32,7 +32,7 @@ class FlightDirectorsDisplay(computers: ComputerBus) : Display(computers) {
         with(guiGraphics) {
             val halfWidth: Int = (HudFrame.width / 10.0f).toInt()
 
-            pose().push()
+            pushPose()
 //? if <1.21.6
             pose().translate(0.0f, 0.0f, -100.0f)
 //? if >=1.21.6 {
@@ -45,23 +45,23 @@ class FlightDirectorsDisplay(computers: ComputerBus) : Display(computers) {
             val pitchInput: ControlInput? = computers.pitch.activeInput
             if (pitchInput != null && pitchInput.priority >= ControlInput.Priority.NORMAL) {
                 yLerper.get(ScreenSpace.getY(pitchInput.target)?.toFloat(), FATickCounter.timePassed * 1.5f)?.roundToInt()?.let {
-                    hLine(this.centerX - halfWidth, this.centerX + halfWidth, it.coerceIn(HudFrame.top + 1..<HudFrame.bottom - 1), primaryAdvisoryColor)
+                    hLine(this.centerX - halfWidth, this.centerX + halfWidth, it.coerceIn(HudFrame.top + 1, HudFrame.bottom - 2), primaryAdvisoryColor)
                 }
             }
 
             val headingInput: ControlInput? = computers.heading.activeInput
             if (headingInput != null && headingInput.priority >= ControlInput.Priority.NORMAL) {
                 xLerper.get(ScreenSpace.getX(headingInput.target)?.toFloat(), FATickCounter.timePassed * 1.5f)?.roundToInt()?.let {
-                    vLine(it.coerceIn(HudFrame.left + 1..<HudFrame.right - 1), this.centerY - halfWidth, this.centerY + halfWidth, primaryAdvisoryColor)
+                    vLine(it.coerceIn(HudFrame.left + 1, HudFrame.right - 2), this.centerY - halfWidth, this.centerY + halfWidth, primaryAdvisoryColor)
                 }
             }
 
             disableScissor()
-            pose().pop()
+            popPose()
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawMiddleAlignedString(Component.translatable("short.flightassistant.flight_directors"), centerX, HudFrame.top + 30, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/FlightPathDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/FlightPathDisplay.kt
@@ -1,6 +1,6 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import org.joml.Vector3f
@@ -16,13 +16,13 @@ class FlightPathDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showFlightPathVector
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val screenSpaceVec: Vector3f = ScreenSpace.getVector3f(computers.hudData.lerpedVelocity, false) ?: return
             val trueX: Float = screenSpaceVec.x
             val trueY: Float = screenSpaceVec.y
 
-            pose().push()
+            pushPose()
 //? if <1.21.6
             pose().translate(0.0f, 0.0f, -150.0f)
             fusedTranslateScale(trueX, trueY, FAConfig.display.flightPathVectorSize)
@@ -40,11 +40,11 @@ class FlightPathDisplay(computers: ComputerBus) : Display(computers) {
             hLine(-bodySideSize - wingSize, -bodySideSize, 0, primaryColor)
             hLine(bodySideSize, bodySideSize + wingSize, 0, primaryColor)
 
-            pose().pop()
+            popPose()
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawMiddleAlignedString(Component.translatable("short.flightassistant.flight_path"), centerX, centerY + 16, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HeadingDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HeadingDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.util.Mth
@@ -19,7 +19,7 @@ class HeadingDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showHeadingReading || FAConfig.display.showHeadingScale
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             if (FAConfig.display.showHeadingReading) {
                 renderHeadingReading()
@@ -33,7 +33,7 @@ class HeadingDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.renderHeadingReading() {
+    private fun FAGuiGraphics.renderHeadingReading() {
         val x: Int = centerX
         val y: Int = HudFrame.bottom + 1
 
@@ -43,7 +43,7 @@ class HeadingDisplay(computers: ComputerBus) : Display(computers) {
         drawMiddleAlignedString("%03d".formatRoot(headingInt), x, y + 2, primaryColor)
     }
 
-    private fun GuiGraphics.renderHeadingScale(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderHeadingScale(x: Int, y: Int) {
         val left: Int = (x - HudFrame.height * 0.5f).toInt()
         val right: Int = (x + HudFrame.height * 0.5f).toInt()
 
@@ -70,16 +70,19 @@ class HeadingDisplay(computers: ComputerBus) : Display(computers) {
         disableScissor()
     }
 
-    private fun GuiGraphics.drawHeadingLine(x: Int, y: Int, left: Int, right: Int, heading: Int, currentHeading: Float, isLeft: Boolean): Boolean {
+    private fun FAGuiGraphics.drawHeadingLine(x: Int, y: Int, left: Int, right: Int, heading: Int, currentHeading: Float, isLeft: Boolean): Boolean {
         val textX: Int = (x + 2 * findShortestPath(currentHeading, heading.toFloat(), 360.0f)).toInt()
         if (textX < left - 100 || textX > right + 100) {
             return false
         }
 
         val wrappedHeading: Int = if (heading > 0) heading % 360 else 360 + heading % 360
-        vLine(textX, y, y + 3, primaryColor)
-        if (wrappedHeading % 30 == 0) {
-            drawMiddleAlignedString((if (wrappedHeading == 0) 360 else wrappedHeading).toString(), textX, y + 4, primaryColor)
+
+        if (textX < x - 12 || textX > x + 12) {
+            vLine(textX, y, y + 3, primaryColor)
+            if (wrappedHeading % 30 == 0) {
+                drawMiddleAlignedString((if (wrappedHeading == 0) 360 else wrappedHeading).toString(), textX, y + 4, primaryColor)
+            }
         }
 
         if (wrappedHeading % 90 == 0) {
@@ -105,14 +108,14 @@ class HeadingDisplay(computers: ComputerBus) : Display(computers) {
         return true
     }
 
-    private fun GuiGraphics.renderHeadingTarget(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderHeadingTarget(x: Int, y: Int) {
         val active: AutoFlightComputer.LateralMode? = computers.autoflight.activeLateralMode
         if ((computers.autoflight.flightDirectors || computers.autoflight.autopilot) && active is AutoFlightComputer.FollowsHeadingMode) {
             drawMiddleAlignedString("%03d".formatRoot(active.targetHeading), x, y, primaryAdvisoryColor)
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawMiddleAlignedString(Component.translatable("short.flightassistant.heading"), centerX, HudFrame.bottom + 1, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HudDisplayHost.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HudDisplayHost.kt
@@ -101,7 +101,7 @@ internal object HudDisplayHost: ModuleController<Display> {
         )
     }
 
-    fun render(guiGraphics: FAGuiGraphics) { FlightAssistant.logger.info("HUD RENDER CALLED!");
+    fun render(guiGraphics: FAGuiGraphics) {
         if (!FAConfig.hudEnabled) {
             return
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HudDisplayHost.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/HudDisplayHost.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -100,7 +101,7 @@ internal object HudDisplayHost: ModuleController<Display> {
         )
     }
 
-    fun render(guiGraphics: GuiGraphics) {
+    fun render(guiGraphics: FAGuiGraphics) { FlightAssistant.logger.info("HUD RENDER CALLED!");
         if (!FAConfig.hudEnabled) {
             return
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/RadarAltitudeDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/RadarAltitudeDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.MutableComponent
 import net.minecraft.resources.ResourceLocation
@@ -18,7 +18,7 @@ class RadarAltitudeDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showRadarAltitude
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         val groundLevel: Double? = computers.gpws.groundY
         if (!computers.chunk.isCurrentLoaded || groundLevel != null && groundLevel > computers.data.altitude) {
             renderFaulted(guiGraphics)
@@ -53,7 +53,7 @@ class RadarAltitudeDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawString(Component.translatable("short.flightassistant.radar_altitude"), HudFrame.right, HudFrame.bottom + 4, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/SpeedDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/SpeedDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -17,7 +17,7 @@ class SpeedDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showSpeedReading || FAConfig.display.showSpeedScale
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             if (FAConfig.display.showSpeedReading) {
                 renderSpeedReading(HudFrame.leftF, centerYF)
@@ -31,8 +31,8 @@ class SpeedDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    private fun GuiGraphics.renderSpeedReading(x: Float, y: Float) {
-        pose().push()
+    private fun FAGuiGraphics.renderSpeedReading(x: Float, y: Float) {
+        pushPose()
         fusedTranslateScale(x * 1.005f, y, READING_MATRIX_SCALE)
 
         val speed: Double = computers.hudData.lerpedForwardVelocity.perSecond().length()
@@ -48,10 +48,10 @@ class SpeedDisplay(computers: ComputerBus) : Display(computers) {
         renderOutline(-width, -halfHeight, width, halfHeight * 2 - 1, color)
         drawRightAlignedString(text, -2, textY, color)
 
-        pose().pop()
+        popPose()
     }
 
-    private fun GuiGraphics.renderSpeedScale(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderSpeedScale(x: Int, y: Int) {
         val speed: Double = computers.hudData.lerpedForwardVelocity.perSecond().length()
         val color: Int =
             if (speed <= 0.0) warningColor
@@ -91,20 +91,22 @@ class SpeedDisplay(computers: ComputerBus) : Display(computers) {
         disableScissor()
     }
 
-    private fun GuiGraphics.drawSpeedLine(x: Int, y: Int, speed: Int, currentSpeed: Double, color: Int): Boolean {
+    private fun FAGuiGraphics.drawSpeedLine(x: Int, y: Int, speed: Int, currentSpeed: Double, color: Int): Boolean {
         val textY: Int = (y + lineHeight * (currentSpeed - speed)).toInt()
         if (textY < HudFrame.top - 100 || textY > HudFrame.bottom + 100) {
             return false
         }
-        hLine(x - 5, x, textY, color)
-        if (speed % 5 == 0) {
-            drawRightAlignedString(speed.toString(), x - 6, textY - 3, color)
+        if (textY < y - 10 || textY > y + 10) {
+            hLine(x - 5, x, textY, color)
+            if (speed % 5 == 0) {
+                drawRightAlignedString(speed.toString(), x - 6, textY - 3, color)
+            }
         }
 
         return true
     }
 
-    private fun GuiGraphics.renderSpeedTarget(x: Int, y: Int) {
+    private fun FAGuiGraphics.renderSpeedTarget(x: Int, y: Int) {
         val color: Int
         val active: AutoFlightComputer.ThrustMode? = computers.autoflight.activeThrustMode
         if (computers.autoflight.autoThrust && active is AutoFlightComputer.FollowsSpeedMode) {
@@ -120,7 +122,7 @@ class SpeedDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawRightAlignedString(
                 Component.translatable("short.flightassistant.speed"),

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/StatusDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/StatusDisplay.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.*
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -18,7 +19,7 @@ class StatusDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showStatusMessages
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.right - 5
             var y: Int = HudFrame.top + 5
@@ -31,7 +32,7 @@ class StatusDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             drawRightAlignedString(Component.translatable("short.flightassistant.status"), HudFrame.right - 5, HudFrame.top + 5, warningColor)
         }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/VelocityComponentsDisplay.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/display/VelocityComponentsDisplay.kt
@@ -1,7 +1,7 @@
 package ru.octol1ttle.flightassistant.impl.display
 
 import kotlin.math.roundToInt
-import net.minecraft.client.gui.GuiGraphics
+import ru.octol1ttle.flightassistant.api.util.extensions.FAGuiGraphics
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.FlightAssistant
@@ -16,7 +16,7 @@ class VelocityComponentsDisplay(computers: ComputerBus) : Display(computers) {
         return FAConfig.display.showGroundSpeed || FAConfig.display.showVerticalSpeed
     }
 
-    override fun render(guiGraphics: GuiGraphics) {
+    override fun render(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.right - 5
             var y: Int = HudFrame.bottom - 10
@@ -42,7 +42,7 @@ class VelocityComponentsDisplay(computers: ComputerBus) : Display(computers) {
         }
     }
 
-    override fun renderFaulted(guiGraphics: GuiGraphics) {
+    override fun renderFaulted(guiGraphics: FAGuiGraphics) {
         with(guiGraphics) {
             val x: Int = HudFrame.right - 25
             var y: Int = HudFrame.bottom - 10

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.screen
 
 import kotlin.properties.Delegates
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
@@ -21,7 +22,13 @@ abstract class FABaseScreen(val parent: Screen?, title: Component) : Screen(titl
         this.addRenderableWidget(SmartStringWidget(this.centerX, 7, this.title).middleAligned())
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+        this.extractBackground(guiGraphics, mouseX, mouseY, partialTick)
+        super.extractRenderState(guiGraphics, mouseX, mouseY, partialTick)
+    }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
 //? if <1.21.6 {
         this.renderBackground(
             guiGraphics
@@ -30,9 +37,10 @@ abstract class FABaseScreen(val parent: Screen?, title: Component) : Screen(titl
 //?}
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+//?}
 
     override fun onClose() {
-        this.minecraft!!.setScreen(parent)
+        this.minecraft!!.setScreenSafe(parent)
     }
 
     override fun isPauseScreen(): Boolean = false

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
@@ -6,6 +6,7 @@ import java.io.FileWriter
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.serialization.json.Json
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.ChatFormatting
 import net.minecraft.Util
 import net.minecraft.client.gui.GuiGraphics
@@ -36,14 +37,14 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
 
         this.addRenderableWidget(SmartStringWidget(this.centerX, this.centerY - 80, Component.translatable("menu.flightassistant.system")).middleAligned())
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.system.manage_displays")) {
-            this.minecraft!!.setScreen(
+            this.minecraft!!.setScreenSafe(
                 SystemManagementScreen(
                     this,
                 Component.translatable("menu.flightassistant.system.manage_displays"), "menu.flightassistant.system.name.hud", HudDisplayHost)
             )
         }.pos(this.centerX - 105, this.centerY - 65).width(100).build())
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.system.manage_computers")) {
-            this.minecraft!!.setScreen(
+            this.minecraft!!.setScreenSafe(
                 SystemManagementScreen(
                     this,
                 Component.translatable("menu.flightassistant.system.manage_computers"), "menu.flightassistant.system.name.computer", ComputerHost)
@@ -51,18 +52,18 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
         }.pos(this.centerX + 5, this.centerY - 65).width(100).build())
 
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.autoflight")) {
-            this.minecraft!!.setScreen(AutoFlightScreen(this))
+            this.minecraft!!.setScreenSafe(AutoFlightScreen(this))
         }.pos(this.centerX - 80, this.centerY - 30).width(160).build())
 
         this.addRenderableWidget(SmartStringWidget(this.centerX, this.centerY + 5, Component.translatable("menu.flightassistant.fms")).middleAligned())
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.fms.departure")) {
-            this.minecraft!!.setScreen(DepartureScreen(this))
+            this.minecraft!!.setScreenSafe(DepartureScreen(this))
         }.pos(this.centerX - 130, this.centerY + 20).width(80).build())
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.fms.enroute")) {
-            this.minecraft!!.setScreen(EnrouteScreen(this))
+            this.minecraft!!.setScreenSafe(EnrouteScreen(this))
         }.pos(this.centerX - 40, this.centerY + 20).width(80).build())
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.fms.arrival")) {
-            this.minecraft!!.setScreen(ArrivalScreen(this))
+            this.minecraft!!.setScreenSafe(ArrivalScreen(this))
         }.pos(this.centerX + 50, this.centerY + 20).width(80).build())
 
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.fms.save")) {
@@ -114,7 +115,7 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
         }.pos(this.centerX + 10, this.centerY + 50).width(80).build())
 
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.config")) {
-            this.minecraft!!.setScreen(FAConfigScreen.generate(this))
+            this.minecraft!!.setScreenSafe(FAConfigScreen.generate(this))
         }.pos(10, this.height - 30).width(120).build())
 
         this.addRenderableWidget(Button.builder(Component.translatable("menu.flightassistant.wiki")) {
@@ -126,12 +127,21 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+
+        if (saveLoadError) {
+            guiGraphics.drawMiddleAlignedString(Component.translatable("menu.flightassistant.fms.error"), this.centerX, this.centerY + 75, ChatFormatting.RED.color!!, true)
+        }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         super.render(guiGraphics, mouseX, mouseY, delta)
 
         if (saveLoadError) {
             guiGraphics.drawMiddleAlignedString(Component.translatable("menu.flightassistant.fms.error"), this.centerX, this.centerY + 75, ChatFormatting.RED.color!!, true)
         }
+//?}
     }
 
     companion object {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.autoflight
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.ChatFormatting
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.Button
@@ -60,13 +61,23 @@ class AutoFlightScreen(parent: Screen) : FABaseScreen(parent, Component.translat
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        updateButton(flightDirectors, "menu.flightassistant.autoflight.flight_directors", computers.autoflight.flightDirectors)
+        updateButton(autoThrust, "menu.flightassistant.autoflight.auto_thrust", computers.autoflight.autoThrust)
+        updateButton(autopilot, "menu.flightassistant.autoflight.autopilot", computers.autoflight.autopilot)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         updateButton(flightDirectors, "menu.flightassistant.autoflight.flight_directors", computers.autoflight.flightDirectors)
         updateButton(autoThrust, "menu.flightassistant.autoflight.auto_thrust", computers.autoflight.autoThrust)
         updateButton(autopilot, "menu.flightassistant.autoflight.autopilot", computers.autoflight.autopilot)
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+//?}
 
     override fun onClose() {
         state.apply(computers.autoflight)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreenState.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreenState.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.screen.autoflight
 
 import dev.isxander.yacl3.api.NameableEnum
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.impl.computer.autoflight.AutoFlightComputer
 import ru.octol1ttle.flightassistant.impl.computer.autoflight.modes.DirectCoordinatesLateralMode

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/CycleTextOnlyButton.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/CycleTextOnlyButton.kt
@@ -2,6 +2,7 @@ package ru.octol1ttle.flightassistant.screen.components
 
 import dev.isxander.yacl3.api.NameableEnum
 import java.util.function.Consumer
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.ChatFormatting
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.AbstractButton
@@ -24,11 +25,13 @@ class CycleTextOnlyButton<E : NameableEnum>(x: Int, y: Int, private val entries:
         refreshMessage()
     }
 
-//? if >=1.21.11 {
-    /*override fun renderContents(
-*///?} else
-    override fun renderWidget(
-        guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+//? if >=26.2 {
+/*    override fun extractContents(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+*///?} else if >=1.21.11 {
+/*    override fun renderContents(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+*///?} else {
+    override fun renderWidget(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+//?}
         val message: Component = TextOnlyButton.getMessageComponent(this)
 
         this.width = font.width(message)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/FABaseList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/FABaseList.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.components
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.components.ContainerObjectSelectionList
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/SmartStringWidget.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/SmartStringWidget.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.components
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.components.StringWidget
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.util.extensions.font

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TextOnlyButton.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TextOnlyButton.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.components
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.AbstractWidget
 import net.minecraft.client.gui.components.Button
@@ -12,11 +13,13 @@ import ru.octol1ttle.flightassistant.api.util.extensions.font
 class TextOnlyButton(val baseX: Int, y: Int, text: Component, onPress: OnPress) : Button(baseX - font.width(text) / 2, y, font.width(text), font.lineHeight, text, onPress, DEFAULT_NARRATION) {
     var color: Int = 0
 
-//? if >=1.21.11 {
-    /*override fun renderContents(
-*///?} else
-    override fun renderWidget(
-        guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+//? if >=26.2 {
+/*    override fun extractContents(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+*///?} else if >=1.21.11 {
+/*    override fun renderContents(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+*///?} else {
+    override fun renderWidget(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
+//?}
         val message: Component = getMessageComponent(this)
 
         this.width = font.width(message)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TypeStrictEditBox.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TypeStrictEditBox.kt
@@ -3,6 +3,7 @@ package ru.octol1ttle.flightassistant.screen.components
 import com.google.common.base.Predicates
 import java.util.function.Consumer
 import java.util.function.Predicate
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.components.EditBox
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.util.extensions.font
@@ -10,10 +11,19 @@ import ru.octol1ttle.flightassistant.api.util.extensions.font
 class TypeStrictEditBox<T>(x: Int, y: Int, width: Int, height: Int, initialValue: T, onValueChange: Consumer<T>, convertFunction: (String) -> T?, filter: Predicate<T> = Predicates.alwaysTrue<T>()) : EditBox(font, x, y, width, height, Component.empty()) {
     init {
         this.value = initialValue.toString()
+//? if <26.2 {
         this.setFilter {
             val value: T? = convertFunction.invoke(it)
             value != null && filter.test(value)
         }
-        this.setResponder { onValueChange.accept(convertFunction.invoke(it)!!) }
+//?}
+        this.setResponder {
+//? if <26.2 {
+            onValueChange.accept(convertFunction.invoke(it)!!)
+//?} else {
+            val v = convertFunction.invoke(it)
+            if (v != null && filter.test(v)) onValueChange.accept(v)
+//?}
+        }
     }
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/arrival/ArrivalScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/arrival/ArrivalScreen.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.fms.arrival
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.screens.Screen
@@ -60,11 +61,19 @@ class ArrivalScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
         super.onClose()
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        discardChanges.active = state != ArrivalScreenState.load(computers.plan.arrivalData)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         discardChanges.active = state != ArrivalScreenState.load(computers.plan.arrivalData)
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+//?}
 
     companion object {
         private var state = ArrivalScreenState()

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/departure/DepartureScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/departure/DepartureScreen.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.fms.departure
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.screens.Screen
@@ -47,11 +48,19 @@ class DepartureScreen(parent: Screen) : FABaseScreen(parent, Component.translata
         super.onClose()
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        discardChanges.active = state != DepartureScreenState.load(computers.plan.departureData)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         discardChanges.active = state != DepartureScreenState.load(computers.plan.departureData)
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+//?}
 
     companion object {
         private var state: DepartureScreenState = DepartureScreenState()

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
@@ -1,6 +1,7 @@
 package ru.octol1ttle.flightassistant.screen.fms.enroute
 
 import kotlin.math.max
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.ChatFormatting
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.Button
@@ -65,7 +66,23 @@ class EnrouteScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+//? if >=26.2 {
+/*    override fun extractRenderState(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, delta: Float) {
+        deleteAll.active = state.waypoints.isNotEmpty()
+
+        val hasUnsavedChanges: Boolean = !state.equals(EnrouteScreenState.load(computers.plan.enrouteData))
+        save.active = hasUnsavedChanges
+        discardChanges.active = hasUnsavedChanges
+        done.active = !hasUnsavedChanges
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+
+        if (hasUnsavedChanges) {
+            val text: Component = Component.translatable("menu.flightassistant.fms.enroute.unsaved_changes")
+            guiGraphics.drawMiddleAlignedString(text, this.width / 4, 7, ChatFormatting.YELLOW.color!!, true)
+        }
+*///?} else {
+    override fun render(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         deleteAll.active = state.waypoints.isNotEmpty()
 
         val hasUnsavedChanges: Boolean = !state.equals(EnrouteScreenState.load(computers.plan.enrouteData))
@@ -79,6 +96,7 @@ class EnrouteScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
             val text: Component = Component.translatable("menu.flightassistant.fms.enroute.unsaved_changes")
             guiGraphics.drawMiddleAlignedString(text, this.width / 4, 7, ChatFormatting.YELLOW.color!!, true)
         }
+//?}
     }
 
     companion object {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteWaypointsList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteWaypointsList.kt
@@ -52,15 +52,19 @@ class EnrouteWaypointsList(y0: Int, y1: Int, width: Int, val columns: Float, val
 
         private var lastFlightPlanActive: FlightPlanComputer.EnrouteWaypoint.Active? = state.active
 
-//? if >=1.21.9 {
-        /*override fun renderContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+//? if >=26.2 {
+/*        override fun extractContent(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, hovered: Boolean, partialTick: Float) {
+            val top = contentY
+            val index = list.children().indexOf(this)
+*///?} else if >=1.21.9 {
+/*        override fun renderContent(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
             val top = contentY
             val index = list.children().indexOf(this)
 *///?} else {
-        override fun render(guiGraphics: GuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+        override fun render(guiGraphics: FAGuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
 //?}
             this.index = index
-            this.hovering = hovering
+            this.hovering = hovered
 
             val flightPlanWaypoint: FlightPlanComputer.EnrouteWaypoint? = state.flightPlanWaypoint
             if (flightPlanWaypoint != null) {
@@ -93,7 +97,7 @@ class EnrouteWaypointsList(y0: Int, y1: Int, width: Int, val columns: Float, val
                 editBox.setBordered(false)
                 editBox.x = (columnWidth * (i + 1)).toInt()
                 editBox.y = top
-                editBox.render(guiGraphics, mouseX, mouseY, partialTick)
+                editBox.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
             }
 
             val hasExtraSpace: Boolean = columns > 7
@@ -102,7 +106,7 @@ class EnrouteWaypointsList(y0: Int, y1: Int, width: Int, val columns: Float, val
                 button.x = buttonX
                 buttonX += button.width + 3
                 button.y = top
-                button.render(guiGraphics, mouseX, mouseY, partialTick)
+                button.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
             }
 
             val distance: Double = distance2d(state.coordinatesX, state.coordinatesZ, computers.data.x, computers.data.z)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.system
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.ChatFormatting
 import net.minecraft.client.gui.GuiGraphics
 import net.minecraft.client.gui.components.Button
@@ -31,15 +32,18 @@ class SystemManagementList(y0: Int, y1: Int, width: Int, baseKey: String, contro
 
         val children = listOf(this.displayName, faultText, offText, toggleButton)
 
-//? if >=1.21.9 {
-        /*override fun renderContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+//? if >=26.2 {
+/*        override fun extractContent(guiGraphics: net.minecraft.client.gui.GuiGraphicsExtractor, mouseX: Int, mouseY: Int, hovered: Boolean, partialTick: Float) {
+            val top = contentY
+*///?} else if >=1.21.9 {
+/*        override fun renderContent(guiGraphics: FAGuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
             val top = contentY
 *///?} else {
-        override fun render(guiGraphics: GuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
-    //?}
+        override fun render(guiGraphics: FAGuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+//?}
             displayName.x = this.xOffset
             displayName.y = top
-            displayName.render(guiGraphics, mouseX, mouseY, partialTick)
+            displayName.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
 
             toggleButton.x = this.listWidth - toggleButton.width - 5
             toggleButton.y = top - toggleButton.height / 4 - 1
@@ -47,17 +51,17 @@ class SystemManagementList(y0: Int, y1: Int, width: Int, baseKey: String, contro
                 if (controller.isEnabled(identifier))
                     if (controller.modulesResettable) OFF_RESET_TEXT else OFF_TEXT
                 else ON_TEXT
-            toggleButton.render(guiGraphics, mouseX, mouseY, partialTick)
+            toggleButton.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
 
             offText.x = toggleButton.x - 10 - font.width(OFF_TEXT)
             offText.y = top
             offText.setColor((if (controller.isEnabled(identifier)) ChatFormatting.DARK_GRAY else ChatFormatting.WHITE).color!!)
-            offText.render(guiGraphics, mouseX, mouseY, partialTick)
+            offText.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
 
             faultText.x = offText.x - offText.width / 2 - font.width(FAULT_TEXT)
             faultText.y = top
             faultText.setColor(if (controller.isFaulted(identifier)) cautionColor else ChatFormatting.DARK_GRAY.color!!)
-            faultText.render(guiGraphics, mouseX, mouseY, partialTick)
+            faultText.renderCompat(guiGraphics, mouseX, mouseY, partialTick)
         }
 
         override fun children(): List<GuiEventListener> {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementScreen.kt
@@ -1,5 +1,6 @@
 package ru.octol1ttle.flightassistant.screen.system
 
+import ru.octol1ttle.flightassistant.api.util.extensions.*
 import net.minecraft.client.gui.components.Button
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.CommonComponents

--- a/versions/1.21.11-fabric/gradle.properties
+++ b/versions/1.21.11-fabric/gradle.properties
@@ -11,6 +11,6 @@ deps.modmenu=17.0.0-alpha.1
 deps.dabr=3.8.3+1.21.11-fabric
 
 # Mod
-mod.mc_version_range=1.21.11
+mod.mc_version_range=>=1.21.11
 mod.mc_title=1.21.11
 mod.mc_targets=1.21.11


### PR DESCRIPTION
This PR introduces the unofficial port of FlightAssistant to Minecraft 26.2, as previously announced and discussed in #87.

Since I already had the working code in my local fork, I am submitting it here as a direct Pull Request to make it easier for you to review and merge into the official project.

    **Key Changes included in this PR:**
    * **Minecraft 26.2 Support:** Updated all necessary dependencies, mappings, and APIs for 26.2 compatibility.
    * **GroundProximityComputer Fix:** Added back the necessary raycast that was previously missing.
    * **HUD Rendering:** Removed an unnecessary debug log during HUD rendering to clean up the console output.
    * **Modrinth Compliance / Documentation:** Fixed broken logo image links, updated the Modrinth badge link to the new slug, and added alt text to images.

