### PR TITLE
feat: add Minecraft 26.2 (Fabric) support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
-    id("dev.isxander.modstitch.base") version "0.7.0-unstable"
-    id("fabric-loom") version "1.14.6" apply false
+    id("dev.isxander.modstitch.base") version "0.8.5"
+    id("fabric-loom") version "1.15.5" apply false
     id("me.modmuss50.mod-publish-plugin")
     id("me.fallenbreath.yamlang") version "1.5.0"
 }
@@ -29,6 +29,13 @@ val minecraftVersionRange = prop("mod.mc_version_range")
 
 // See https://stonecutter.kikugie.dev/stonecutter/guide/comments#condition-constants
 val loader: String = name.split("-")[1]
+
+// Minecraft 26.x (unobfuscated) requires Java 25, 1.20.6+ requires Java 21, older requires Java 17
+val javaVersionTarget: Int = when {
+    stonecutter.eval(minecraft, ">=26") -> 25
+    stonecutter.eval(minecraft, ">=1.20.6") -> 21
+    else -> 17
+}
 stonecutter {
     constants {
         match(loader, "fabric", "neoforge", "forge")
@@ -47,15 +54,14 @@ tasks.withType<Jar> {
 modstitch {
     minecraftVersion = minecraft
 
-    val j21: Boolean = stonecutter.eval(minecraft, ">=1.20.6")
-    javaVersion = if (j21) 21 else 17
+    javaVersion = javaVersionTarget
 
     java {
         withSourcesJar()
     }
 
     kotlin {
-        jvmToolchain(if (j21) 21 else 17)
+        jvmToolchain(javaVersionTarget)
     }
 
     // If parchment doesnt exist for a version yet you can safely
@@ -81,6 +87,8 @@ modstitch {
             put("fml", if (loader == "neoforge") "1" else "45")
             put("mnd", if (loader == "neoforge") "type = \"required\"" else "mandatory = true")
             put("refmap", if (loader == "forge") refmapString else "")
+            put("flmin", if (loader == "fabric") ">=${prop("deps.fabric_loader")}" else "")
+            put("javamin", ">=$javaVersionTarget")
         }
 
         overwriteProjectVersionAndGroup = false
@@ -145,7 +153,7 @@ dependencies {
 
     modstitch.loom {
         modstitchModImplementation("net.fabricmc.fabric-api:fabric-api:${property("deps.fapi")}")
-        modstitchModImplementation("net.fabricmc:fabric-language-kotlin:${property("deps.flk")}+kotlin.2.1.0")
+        modstitchModImplementation("net.fabricmc:fabric-language-kotlin:${property("deps.flk")}+${property("deps.flk_kotlin")}")
         modstitchModImplementation("com.terraformersmc:modmenu:${property("deps.modmenu")}")
     }
 
@@ -171,6 +179,23 @@ dependencies {
 yamlang {
     targetSourceSets.set(mutableListOf(sourceSets["main"]))
     inputDir.set("assets/${mod.id}/lang")
+}
+
+// Modstitch's source configuration overrides stonecutter's automatic wiring of
+// the preprocessed (chiseled) sources into the compile source set, so we wire
+// them up explicitly here. The generated (preprocessed) sources fully replace
+// the shared raw sources under src/main.
+sourceSets["main"].apply {
+    // Kotlin srcDirs must also include the generated Java dir so Kotlin/Java
+    // joint compilation sees the Java classes (e.g. mixin invokers, interfaces).
+    kotlin.setSrcDirs(listOf(
+        layout.buildDirectory.dir("generated/stonecutter/main/kotlin"),
+        layout.buildDirectory.dir("generated/stonecutter/main/java"),
+    ))
+    java.setSrcDirs(listOf(layout.buildDirectory.dir("generated/stonecutter/main/java")))
+}
+tasks.matching { it.name == "compileKotlin" || it.name == "compileJava" || it.name == "sourcesJar" || it.name == "processResources" }.configureEach {
+    dependsOn(tasks.named("stonecutterGenerate"))
 }
 
 // Publishing

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ mod.version=3.1.0
 deps.mixin_extras=0.4.1
 deps.fabric_loader=0.16.10
 deps.flk=1.13.0
+deps.flk_kotlin=kotlin.2.1.0
 
 publish.modrinth=CWqLEOPt
 publish.curseforge=972881

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ stonecutter {
         mc("1.21.6", "fabric")
         mc("1.21.9", "fabric")
         mc("1.21.11", "fabric")
+        mc("26.2", "fabric")
     }
 }
 

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinHud26.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinHud26.java
@@ -1,0 +1,15 @@
+package ru.octol1ttle.flightassistant.mixin.gui;
+
+import net.minecraft.client.gui.Hud;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(Hud.class)
+abstract class GuiMixinHud26 {
+//? if >=26 {
+    /*@org.spongepowered.asm.mixin.injection.Inject(method = "extractRenderState", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Hud;extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V"))
+    private void beforeExtractHotbarAndDecorations(net.minecraft.client.gui.GuiGraphicsExtractor guiGraphics, net.minecraft.client.DeltaTracker deltaTracker, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        ru.octol1ttle.flightassistant.api.util.event.FixedGuiRenderCallback.EVENT.invoker().onRenderGui(guiGraphics, deltaTracker.getGameTimeDeltaPartialTick(true));
+        guiGraphics.nextStratum();
+    }
+*///?}
+}

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinHud26.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinHud26.java
@@ -1,9 +1,13 @@
 package ru.octol1ttle.flightassistant.mixin.gui;
 
-import net.minecraft.client.gui.Hud;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
 
-@Mixin(Hud.class)
+// The HUD class was renamed Gui -> Hud in 26.x, so this mixin targets a class that
+// only exists on 26+. @Pseudo makes the mixin a no-op (skipped with a warning) on
+// older versions where the target is absent, so it can stay registered in the config.
+@Pseudo
+@Mixin(targets = "net.minecraft.client.gui.Hud")
 abstract class GuiMixinHud26 {
 //? if >=26 {
     /*@org.spongepowered.asm.mixin.injection.Inject(method = "extractRenderState", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Hud;extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V"))

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinNew.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/gui/GuiMixinNew.java
@@ -5,7 +5,7 @@ import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(Gui.class)
 abstract class GuiMixinNew {
-//? if fabric && >=1.21.6 {
+//? if fabric && >=1.21.6 && <26 {
     /*@org.spongepowered.asm.mixin.injection.Inject(method = "render", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;renderHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V"))
     private void beforeRenderHotbarAndDecorations(net.minecraft.client.gui.GuiGraphics guiGraphics, net.minecraft.client.DeltaTracker deltaTracker, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
         ru.octol1ttle.flightassistant.api.util.event.FixedGuiRenderCallback.EVENT.invoker().onRenderGui(guiGraphics, deltaTracker.getGameTimeDeltaPartialTick(true));

--- a/src/main/java/ru/octol1ttle/flightassistant/mixin/level_renderer/LevelRendererMixinNewestest.java
+++ b/src/main/java/ru/octol1ttle/flightassistant/mixin/level_renderer/LevelRendererMixinNewestest.java
@@ -5,10 +5,19 @@ import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(LevelRenderer.class)
 abstract class LevelRendererMixinNewestest {
-//? if >=1.21.9 {
+//? if >=1.21.9 && <26 {
     /*@org.spongepowered.asm.mixin.injection.Inject(method = "renderLevel", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
     private void onStartRender(com.mojang.blaze3d.resource.GraphicsResourceAllocator graphicsResourceAllocator, net.minecraft.client.DeltaTracker deltaTracker, boolean renderBlockOutline, net.minecraft.client.Camera camera, org.joml.Matrix4f frustumMatrix, org.joml.Matrix4f projectionMatrix, org.joml.Matrix4f cullingProjectionMatrix, com.mojang.blaze3d.buffers.GpuBufferSlice fogBuffer, org.joml.Vector4f fogColor, boolean renderSky, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
         ru.octol1ttle.flightassistant.api.util.event.LevelRenderCallback.EVENT.invoker().onStartRenderLevel(deltaTracker.getGameTimeDeltaPartialTick(true), camera, projectionMatrix, frustumMatrix.get3x3(new org.joml.Matrix3f()));
+    }
+*///?}
+//? if >=26 {
+    /*@org.spongepowered.asm.mixin.injection.Inject(method = "render", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
+    private void onStartRender(com.mojang.blaze3d.resource.GraphicsResourceAllocator graphicsResourceAllocator, net.minecraft.client.DeltaTracker deltaTracker, boolean renderBlockOutline, net.minecraft.client.renderer.state.level.CameraRenderState cameraRenderState, org.joml.Matrix4fc frustumMatrix, com.mojang.blaze3d.buffers.GpuBufferSlice fogBuffer, org.joml.Vector4f fogColor, boolean renderSky, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        net.minecraft.client.Camera camera = net.minecraft.client.Minecraft.getInstance().gameRenderer.mainCamera();
+        if (camera != null) {
+            ru.octol1ttle.flightassistant.api.util.event.LevelRenderCallback.EVENT.invoker().onStartRenderLevel(deltaTracker.getGameTimeDeltaPartialTick(true), camera, cameraRenderState.projectionMatrix, frustumMatrix.get3x3(new org.joml.Matrix3f()));
+        }
     }
 *///?}
 }

--- a/src/main/kotlin/net/minecraft/client/gui/GuiGraphics.kt
+++ b/src/main/kotlin/net/minecraft/client/gui/GuiGraphics.kt
@@ -1,0 +1,5 @@
+package net.minecraft.client.gui
+
+//? if >=26 {
+/*typealias GuiGraphics = GuiGraphicsExtractor
+*///?}

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
@@ -5,7 +5,9 @@ import net.minecraft.client.KeyMapping
 import org.lwjgl.glfw.GLFW
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
-import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+*///?}
 import ru.octol1ttle.flightassistant.config.FAConfig
 import ru.octol1ttle.flightassistant.screen.FlightAssistantSetupScreen
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FAKeyMappings.kt
@@ -5,6 +5,7 @@ import net.minecraft.client.KeyMapping
 import org.lwjgl.glfw.GLFW
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
+import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
 import ru.octol1ttle.flightassistant.config.FAConfig
 import ru.octol1ttle.flightassistant.screen.FlightAssistantSetupScreen
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistant.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/FlightAssistant.kt
@@ -52,6 +52,9 @@ object FlightAssistant {
 
             RenderMatrices.projectionMatrix.set(projectionMatrix)
             RenderMatrices.worldSpaceMatrix.set(frustumMatrix)
+            //? if >=26 {
+            /*RenderMatrices.modelViewMatrix.identity()
+*///?} else
             RenderMatrices.modelViewMatrix.set(RenderSystem.getModelViewMatrix())
 
             RenderMatrices.worldSpaceNoRollMatrix.set(Matrix4f().apply {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/ScreenSpace.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/ScreenSpace.kt
@@ -5,14 +5,18 @@ import org.jetbrains.annotations.Contract
 import org.joml.Matrix4f
 import org.joml.Vector3f
 import org.joml.Vector4f
-import org.lwjgl.opengl.GL11
 import ru.octol1ttle.flightassistant.FlightAssistant.mc
 
 object ScreenSpace {
     private var viewport: IntArray = IntArray(4)
 
     internal fun updateViewport() {
-        GL11.glGetIntegerv(GL11.GL_VIEWPORT, viewport)
+        // The HUD is now extracted during the CPU render-state phase (26.x), where the
+        // GL viewport is stale. Project against the actual framebuffer size instead.
+        viewport[0] = 0
+        viewport[1] = 0
+        viewport[2] = mc.window.width
+        viewport[3] = mc.window.height
     }
 
     /**
@@ -52,10 +56,24 @@ object ScreenSpace {
         val matrixModel = Matrix4f(RenderMatrices.modelViewMatrix)
 
         matrixProj.mul(matrixModel)
-            .project(
-                transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), viewport,
-                target
-            )
+
+        // On 26.x the projection matrix uses a reversed-Z depth range. Points that are at
+        // or behind the camera plane (clip.w <= 0) get mirrored back into the visible depth
+        // window, so the generic z-range check below can no longer reject them. Reject them
+        // here explicitly, otherwise e.g. both pitch-limit arrows end up drawn at once.
+        val clipW: Float =
+            matrixProj.m03() * transformedCoordinates.x +
+                matrixProj.m13() * transformedCoordinates.y +
+                matrixProj.m23() * transformedCoordinates.z +
+                matrixProj.m33() * transformedCoordinates.w
+        if (clipW <= 0.0f) {
+            return Vector3f(-1.0f, -1.0f, 2.0f)
+        }
+
+        matrixProj.project(
+            transformedCoordinates.x(), transformedCoordinates.y(), transformedCoordinates.z(), viewport,
+            target
+        )
 
         return Vector3f(
             target.x / mc.window.guiScale.toFloat(),

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsCompat26.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsCompat26.kt
@@ -1,0 +1,92 @@
+package ru.octol1ttle.flightassistant.api.util.extensions
+
+// Compatibility shims for Minecraft 26.x, where `GuiGraphics` was replaced by the
+// `GuiGraphicsExtractor` render-state model. These only apply on 26+, on older
+// versions `GuiGraphics` is still a real class with these members.
+//? if >=26 {
+/*import net.minecraft.client.gui.Font
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.network.chat.Component
+import org.joml.Matrix3x2fStack
+import org.joml.Quaternionfc
+import kotlin.math.atan2
+
+fun GuiGraphicsExtractor.drawString(font: Font, text: String, x: Int, y: Int, color: Int, shadow: Boolean = false): Int {
+    text(font, text, x, y, color, shadow)
+    return 1
+}
+
+fun GuiGraphicsExtractor.drawString(font: Font, text: Component, x: Int, y: Int, color: Int, shadow: Boolean = false): Int {
+    text(font, text, x, y, color, shadow)
+    return 1
+}
+
+fun GuiGraphicsExtractor.drawCenteredString(font: Font, text: Component, x: Int, y: Int, color: Int): Int {
+    centeredText(font, text, x, y, color)
+    return 1
+}
+
+fun GuiGraphicsExtractor.hLine(x1: Int, x2: Int, y: Int, color: Int) {
+    horizontalLine(x1, x2, y, color)
+}
+
+fun GuiGraphicsExtractor.vLine(x: Int, y1: Int, y2: Int, color: Int) {
+    verticalLine(x, y1, y2, color)
+}
+
+fun Matrix3x2fStack.translate(x: Float, y: Float, z: Float): Matrix3x2fStack {
+    translate(x, y)
+    return this
+}
+
+fun Matrix3x2fStack.mulPose(q: Quaternionfc): Matrix3x2fStack {
+    rotate(2f * atan2(q.z(), q.w()))
+    return this
+}
+
+fun Matrix3x2fStack.rotateAround(q: Quaternionfc, x: Float, y: Float, z: Float): Matrix3x2fStack {
+    translate(x, y)
+    rotate(2f * atan2(q.z(), q.w()))
+    translate(-x, -y)
+    return this
+}
+
+// ChatFormatting lost its `color` field in 26.x; provide it as an extension.
+val net.minecraft.ChatFormatting.color: Int?
+    get() = when (this) {
+        net.minecraft.ChatFormatting.BLACK -> 0x000000
+        net.minecraft.ChatFormatting.DARK_BLUE -> 0x0000AA
+        net.minecraft.ChatFormatting.DARK_GREEN -> 0x00AA00
+        net.minecraft.ChatFormatting.DARK_AQUA -> 0x00AAAA
+        net.minecraft.ChatFormatting.DARK_RED -> 0xAA0000
+        net.minecraft.ChatFormatting.DARK_PURPLE -> 0xAA00AA
+        net.minecraft.ChatFormatting.GOLD -> 0xFFAA00
+        net.minecraft.ChatFormatting.GRAY -> 0xAAAAAA
+        net.minecraft.ChatFormatting.DARK_GRAY -> 0x555555
+        net.minecraft.ChatFormatting.BLUE -> 0x5555FF
+        net.minecraft.ChatFormatting.GREEN -> 0x55FF55
+        net.minecraft.ChatFormatting.AQUA -> 0x55FFFF
+        net.minecraft.ChatFormatting.RED -> 0xFF5555
+        net.minecraft.ChatFormatting.LIGHT_PURPLE -> 0xFF55FF
+        net.minecraft.ChatFormatting.YELLOW -> 0xFFFF55
+        net.minecraft.ChatFormatting.WHITE -> 0xFFFFFF
+        else -> null
+    }
+
+// Minecraft.setScreen was renamed to setScreenAndShow in 26.x, and the current
+// screen/overlay moved to Minecraft.gui.
+fun net.minecraft.client.Minecraft.setScreen(screen: net.minecraft.client.gui.screens.Screen?) {
+    gui.setScreen(screen)
+}
+
+val net.minecraft.client.Minecraft.screen: net.minecraft.client.gui.screens.Screen?
+    get() = gui.screen()
+
+val net.minecraft.client.Minecraft.overlay: net.minecraft.client.gui.screens.Overlay?
+    get() = gui.overlay()
+
+// Renderable no longer has `render`, it now uses `extractRenderState`.
+fun net.minecraft.client.gui.components.Renderable.render(guiGraphics: GuiGraphicsExtractor, mouseX: Int, mouseY: Int, partialTick: Float) {
+    extractRenderState(guiGraphics, mouseX, mouseY, partialTick)
+}
+*///?}

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsExtensions.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/api/util/extensions/GuiGraphicsExtensions.kt
@@ -156,13 +156,23 @@ fun org.joml.Matrix3x2fStack.pop() {
     popMatrix()
 }
 
+//? if >=26 {
+/*fun GuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
+    outline(x, y, width, height, color)
+}
+*///?} else {
+//? if >=1.21.11 {
+/*fun GuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
+    renderOutline(x, y, width, height, color)
+}
+*///?} else {
 //? if >=1.21.9 {
 /*fun GuiGraphics.renderOutline(x: Int, y: Int, width: Int, height: Int, color: Int) {
-//? if >=1.21.11 {
-    /^renderOutline(
-^///?} else
-    submitOutline(
-        x, y, width, height, color)
+    submitOutline(x, y, width, height, color)
     renderDeferredElements()
 }
-*///?}
+*///?} else {
+    // (<1.21.9) vanilla GuiGraphics.renderOutline exists; no extension needed.
+//?}
+//?}
+//?}

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FireworkComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/autoflight/FireworkComputer.kt
@@ -41,10 +41,15 @@ class FireworkComputer(computers: ComputerBus, private val mc: Minecraft) : Comp
                 val explosive = FAConfig.safety.fireworkLockExplosive && !isEmptyOrSafe(player, hand)
                 val anyTerrainAhead = FAConfig.safety.fireworkLockObstacles && anyTerrainAhead()
                 if (computers.data.automationsAllowed() && (explosive || anyTerrainAhead)) {
+//? if >=26 {
+                    /*return@RightClickItem dev.architectury.event.EventResult.interruptFalse()
+*///?} else {
 //? if >=1.21.2 {
                     /*return@RightClickItem net.minecraft.world.InteractionResult.FAIL
-*///?} else
+*///?} else {
                     return@RightClickItem dev.architectury.event.CompoundEventResult.interruptFalse(stack)
+//?}
+//?}
                 }
 
                 if (!waitingForResponse) {
@@ -53,10 +58,15 @@ class FireworkComputer(computers: ComputerBus, private val mc: Minecraft) : Comp
                 }
             }
 
+//? if >=26 {
+            /*return@RightClickItem dev.architectury.event.EventResult.pass()
+*///?} else {
 //? if >=1.21.2 {
             /*return@RightClickItem net.minecraft.world.InteractionResult.PASS
-*///?} else
+*///?} else {
             return@RightClickItem dev.architectury.event.CompoundEventResult.pass()
+//?}
+//?}
         })
         FireworkBoostCallback.EVENT.register(FireworkBoostCallback { _, _ ->
             if (waitingForResponse) {

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
@@ -18,7 +18,9 @@ import ru.octol1ttle.flightassistant.api.computer.ComputerBus
 import ru.octol1ttle.flightassistant.api.util.degrees
 import ru.octol1ttle.flightassistant.api.util.extensions.bottomY
 import ru.octol1ttle.flightassistant.api.util.extensions.getLerpedDeltaMovement
+import ru.octol1ttle.flightassistant.api.util.extensions.overlay
 import ru.octol1ttle.flightassistant.api.util.extensions.perSecond
+import ru.octol1ttle.flightassistant.api.util.extensions.screen
 import ru.octol1ttle.flightassistant.api.util.throwIfNotInRange
 import ru.octol1ttle.flightassistant.config.FAConfig
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/impl/computer/data/AirDataComputer.kt
@@ -18,9 +18,13 @@ import ru.octol1ttle.flightassistant.api.computer.ComputerBus
 import ru.octol1ttle.flightassistant.api.util.degrees
 import ru.octol1ttle.flightassistant.api.util.extensions.bottomY
 import ru.octol1ttle.flightassistant.api.util.extensions.getLerpedDeltaMovement
-import ru.octol1ttle.flightassistant.api.util.extensions.overlay
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.overlay
+*///?}
 import ru.octol1ttle.flightassistant.api.util.extensions.perSecond
-import ru.octol1ttle.flightassistant.api.util.extensions.screen
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.screen
+*///?}
 import ru.octol1ttle.flightassistant.api.util.throwIfNotInRange
 import ru.octol1ttle.flightassistant.config.FAConfig
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
@@ -6,7 +6,9 @@ import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.FAKeyMappings
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
-import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+*///?}
 import ru.octol1ttle.flightassistant.impl.computer.ComputerHost
 import ru.octol1ttle.flightassistant.screen.components.SmartStringWidget
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FABaseScreen.kt
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.FAKeyMappings
 import ru.octol1ttle.flightassistant.api.computer.ComputerBus
+import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
 import ru.octol1ttle.flightassistant.impl.computer.ComputerHost
 import ru.octol1ttle.flightassistant.screen.components.SmartStringWidget
 
@@ -21,7 +22,13 @@ abstract class FABaseScreen(val parent: Screen?, title: Component) : Screen(titl
         this.addRenderableWidget(SmartStringWidget(this.centerX, 7, this.title).middleAligned())
     }
 
-    override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
+    override fun render(
+        guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
 //? if <1.21.6 {
         this.renderBackground(
             guiGraphics
@@ -30,6 +37,7 @@ abstract class FABaseScreen(val parent: Screen?, title: Component) : Screen(titl
 //?}
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+    //?}
 
     override fun onClose() {
         this.minecraft!!.setScreen(parent)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
@@ -16,7 +16,9 @@ import org.lwjgl.PointerBuffer
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.util.tinyfd.TinyFileDialogs
 import ru.octol1ttle.flightassistant.FlightAssistant
+import ru.octol1ttle.flightassistant.api.util.extensions.color
 import ru.octol1ttle.flightassistant.api.util.extensions.drawMiddleAlignedString
+import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
 import ru.octol1ttle.flightassistant.config.FAConfigScreen
 import ru.octol1ttle.flightassistant.impl.computer.ComputerHost
 import ru.octol1ttle.flightassistant.impl.computer.autoflight.FlightPlanComputer
@@ -126,6 +128,15 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+
+        if (saveLoadError) {
+            guiGraphics.drawMiddleAlignedString(Component.translatable("menu.flightassistant.fms.error"), this.centerX, this.centerY + 75, ChatFormatting.RED.color!!, true)
+        }
+    }
+*///?} else {
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         super.render(guiGraphics, mouseX, mouseY, delta)
 
@@ -133,6 +144,7 @@ class FlightAssistantSetupScreen : FABaseScreen(null, Component.translatable("me
             guiGraphics.drawMiddleAlignedString(Component.translatable("menu.flightassistant.fms.error"), this.centerX, this.centerY + 75, ChatFormatting.RED.color!!, true)
         }
     }
+    //?}
 
     companion object {
         val PLANS_PATH: Path = YACLPlatform.getConfigDir().resolve("${FlightAssistant.MOD_ID}/plans")

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/FlightAssistantSetupScreen.kt
@@ -16,9 +16,13 @@ import org.lwjgl.PointerBuffer
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.util.tinyfd.TinyFileDialogs
 import ru.octol1ttle.flightassistant.FlightAssistant
-import ru.octol1ttle.flightassistant.api.util.extensions.color
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.color
+*///?}
 import ru.octol1ttle.flightassistant.api.util.extensions.drawMiddleAlignedString
-import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.setScreen
+*///?}
 import ru.octol1ttle.flightassistant.config.FAConfigScreen
 import ru.octol1ttle.flightassistant.impl.computer.ComputerHost
 import ru.octol1ttle.flightassistant.impl.computer.autoflight.FlightPlanComputer

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.components.events.GuiEventListener
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.CommonComponents
 import net.minecraft.network.chat.Component
+import ru.octol1ttle.flightassistant.api.util.extensions.color
 import ru.octol1ttle.flightassistant.api.util.extensions.toFloatOrNullWithFallback
 import ru.octol1ttle.flightassistant.api.util.extensions.toIntOrNullWithFallback
 import ru.octol1ttle.flightassistant.screen.FABaseScreen
@@ -60,6 +61,15 @@ class AutoFlightScreen(parent: Screen) : FABaseScreen(parent, Component.translat
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        updateButton(flightDirectors, "menu.flightassistant.autoflight.flight_directors", computers.autoflight.flightDirectors)
+        updateButton(autoThrust, "menu.flightassistant.autoflight.auto_thrust", computers.autoflight.autoThrust)
+        updateButton(autopilot, "menu.flightassistant.autoflight.autopilot", computers.autoflight.autopilot)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         updateButton(flightDirectors, "menu.flightassistant.autoflight.flight_directors", computers.autoflight.flightDirectors)
         updateButton(autoThrust, "menu.flightassistant.autoflight.auto_thrust", computers.autoflight.autoThrust)
@@ -67,6 +77,7 @@ class AutoFlightScreen(parent: Screen) : FABaseScreen(parent, Component.translat
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+    //?}
 
     override fun onClose() {
         state.apply(computers.autoflight)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/autoflight/AutoFlightScreen.kt
@@ -7,7 +7,9 @@ import net.minecraft.client.gui.components.events.GuiEventListener
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.network.chat.CommonComponents
 import net.minecraft.network.chat.Component
-import ru.octol1ttle.flightassistant.api.util.extensions.color
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.color
+*///?}
 import ru.octol1ttle.flightassistant.api.util.extensions.toFloatOrNullWithFallback
 import ru.octol1ttle.flightassistant.api.util.extensions.toIntOrNullWithFallback
 import ru.octol1ttle.flightassistant.screen.FABaseScreen

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/CycleTextOnlyButton.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/CycleTextOnlyButton.kt
@@ -11,6 +11,7 @@ import net.minecraft.network.chat.MutableComponent
 import net.minecraft.network.chat.Style
 import net.minecraft.util.Mth
 import ru.octol1ttle.flightassistant.api.util.extensions.appendWithSeparation
+import ru.octol1ttle.flightassistant.api.util.extensions.drawString
 import ru.octol1ttle.flightassistant.api.util.extensions.font
 import ru.octol1ttle.flightassistant.api.util.extensions.whiteColor
 
@@ -24,10 +25,15 @@ class CycleTextOnlyButton<E : NameableEnum>(x: Int, y: Int, private val entries:
         refreshMessage()
     }
 
+//? if >=26 {
+    /*override fun extractContents(
+*///?} else {
 //? if >=1.21.11 {
     /*override fun renderContents(
-*///?} else
+*///?} else {
     override fun renderWidget(
+//?}
+//?}
         guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
         val message: Component = TextOnlyButton.getMessageComponent(this)
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TextOnlyButton.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TextOnlyButton.kt
@@ -7,15 +7,21 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.ComponentUtils
 import net.minecraft.network.chat.Style
 import net.minecraft.util.Mth
+import ru.octol1ttle.flightassistant.api.util.extensions.drawString
 import ru.octol1ttle.flightassistant.api.util.extensions.font
 
 class TextOnlyButton(val baseX: Int, y: Int, text: Component, onPress: OnPress) : Button(baseX - font.width(text) / 2, y, font.width(text), font.lineHeight, text, onPress, DEFAULT_NARRATION) {
     var color: Int = 0
 
+//? if >=26 {
+    /*override fun extractContents(
+*///?} else {
 //? if >=1.21.11 {
     /*override fun renderContents(
-*///?} else
+*///?} else {
     override fun renderWidget(
+//?}
+//?}
         guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, partialTick: Float) {
         val message: Component = getMessageComponent(this)
 

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TypeStrictEditBox.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/components/TypeStrictEditBox.kt
@@ -7,13 +7,40 @@ import net.minecraft.client.gui.components.EditBox
 import net.minecraft.network.chat.Component
 import ru.octol1ttle.flightassistant.api.util.extensions.font
 
-class TypeStrictEditBox<T>(x: Int, y: Int, width: Int, height: Int, initialValue: T, onValueChange: Consumer<T>, convertFunction: (String) -> T?, filter: Predicate<T> = Predicates.alwaysTrue<T>()) : EditBox(font, x, y, width, height, Component.empty()) {
+class TypeStrictEditBox<T>(x: Int, y: Int, width: Int, height: Int, initialValue: T, onValueChange: Consumer<T>, val convertFunction: (String) -> T?, val filter: Predicate<T> = Predicates.alwaysTrue<T>()) : EditBox(font, x, y, width, height, Component.empty()) {
     init {
         this.value = initialValue.toString()
+//? if <26 {
         this.setFilter {
             val value: T? = convertFunction.invoke(it)
             value != null && filter.test(value)
         }
+//?}
         this.setResponder { onValueChange.accept(convertFunction.invoke(it)!!) }
     }
+
+//? if >=26 {
+    /*// 26.x removed EditBox.setFilter; guard the mutation methods instead so the
+    // value can never become invalid (the responder relies on that with `!!`).
+    override fun insertText(text: String) {
+        applyIfValid { super.insertText(text) }
+    }
+
+    override fun deleteChars(i: Int) {
+        applyIfValid { super.deleteChars(i) }
+    }
+
+    override fun deleteWords(i: Int) {
+        applyIfValid { super.deleteWords(i) }
+    }
+
+    private fun applyIfValid(change: () -> Unit) {
+        val original: String = this.value
+        change()
+        val parsed: T? = convertFunction.invoke(this.value)
+        if (parsed == null || !filter.test(parsed)) {
+            this.value = original
+        }
+    }
+*///?}
 }

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/arrival/ArrivalScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/arrival/ArrivalScreen.kt
@@ -60,11 +60,19 @@ class ArrivalScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
         super.onClose()
     }
 
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        discardChanges.active = state != ArrivalScreenState.load(computers.plan.arrivalData)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         discardChanges.active = state != ArrivalScreenState.load(computers.plan.arrivalData)
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+    //?}
 
     companion object {
         private var state = ArrivalScreenState()

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/departure/DepartureScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/departure/DepartureScreen.kt
@@ -47,11 +47,19 @@ class DepartureScreen(parent: Screen) : FABaseScreen(parent, Component.translata
         super.onClose()
     }
 
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        discardChanges.active = state != DepartureScreenState.load(computers.plan.departureData)
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+    }
+*///?} else {
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         discardChanges.active = state != DepartureScreenState.load(computers.plan.departureData)
 
         super.render(guiGraphics, mouseX, mouseY, delta)
     }
+    //?}
 
     companion object {
         private var state: DepartureScreenState = DepartureScreenState()

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
@@ -11,7 +11,9 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.literal
 import net.minecraft.network.chat.Component.translatable
 import net.minecraft.network.chat.Style
-import ru.octol1ttle.flightassistant.api.util.extensions.color
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.color
+*///?}
 import ru.octol1ttle.flightassistant.api.util.extensions.drawMiddleAlignedString
 import ru.octol1ttle.flightassistant.api.util.extensions.primaryAdvisoryColor
 import ru.octol1ttle.flightassistant.api.util.extensions.setColor

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteScreen.kt
@@ -11,6 +11,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Component.literal
 import net.minecraft.network.chat.Component.translatable
 import net.minecraft.network.chat.Style
+import ru.octol1ttle.flightassistant.api.util.extensions.color
 import ru.octol1ttle.flightassistant.api.util.extensions.drawMiddleAlignedString
 import ru.octol1ttle.flightassistant.api.util.extensions.primaryAdvisoryColor
 import ru.octol1ttle.flightassistant.api.util.extensions.setColor
@@ -65,6 +66,23 @@ class EnrouteScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
         }.pos(this.width - 90, this.height - 30).width(80).build())
     }
 
+    //? if >=26 {
+    /*override fun extractRenderState(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
+        deleteAll.active = state.waypoints.isNotEmpty()
+
+        val hasUnsavedChanges: Boolean = !state.equals(EnrouteScreenState.load(computers.plan.enrouteData))
+        save.active = hasUnsavedChanges
+        discardChanges.active = hasUnsavedChanges
+        done.active = !hasUnsavedChanges
+
+        super.extractRenderState(guiGraphics, mouseX, mouseY, delta)
+
+        if (hasUnsavedChanges) {
+            val text: Component = Component.translatable("menu.flightassistant.fms.enroute.unsaved_changes")
+            guiGraphics.drawMiddleAlignedString(text, this.width / 4, 7, ChatFormatting.YELLOW.color!!, true)
+        }
+    }
+*///?} else {
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
         deleteAll.active = state.waypoints.isNotEmpty()
 
@@ -80,6 +98,7 @@ class EnrouteScreen(parent: Screen) : FABaseScreen(parent, Component.translatabl
             guiGraphics.drawMiddleAlignedString(text, this.width / 4, 7, ChatFormatting.YELLOW.color!!, true)
         }
     }
+    //?}
 
     companion object {
         private const val Y0: Int = 30

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteWaypointsList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/fms/enroute/EnrouteWaypointsList.kt
@@ -52,12 +52,18 @@ class EnrouteWaypointsList(y0: Int, y1: Int, width: Int, val columns: Float, val
 
         private var lastFlightPlanActive: FlightPlanComputer.EnrouteWaypoint.Active? = state.active
 
+//? if >=26 {
+        /*override fun extractContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+            val top = contentY
+            val index = list.children().indexOf(this)
+*///?} else {
 //? if >=1.21.9 {
         /*override fun renderContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
             val top = contentY
             val index = list.children().indexOf(this)
 *///?} else {
         override fun render(guiGraphics: GuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+//?}
 //?}
             this.index = index
             this.hovering = hovering

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
@@ -10,7 +10,9 @@ import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.api.ModuleController
 import ru.octol1ttle.flightassistant.api.util.extensions.cautionColor
+import ru.octol1ttle.flightassistant.api.util.extensions.color
 import ru.octol1ttle.flightassistant.api.util.extensions.font
+import ru.octol1ttle.flightassistant.api.util.extensions.render
 import ru.octol1ttle.flightassistant.screen.components.FABaseList
 import ru.octol1ttle.flightassistant.screen.components.SmartStringWidget
 
@@ -31,12 +33,17 @@ class SystemManagementList(y0: Int, y1: Int, width: Int, baseKey: String, contro
 
         val children = listOf(this.displayName, faultText, offText, toggleButton)
 
+//? if >=26 {
+        /*override fun extractContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
+            val top = contentY
+*///?} else {
 //? if >=1.21.9 {
         /*override fun renderContent(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
             val top = contentY
 *///?} else {
         override fun render(guiGraphics: GuiGraphics, index: Int, top: Int, left: Int, width: Int, height: Int, mouseX: Int, mouseY: Int, hovering: Boolean, partialTick: Float) {
     //?}
+//?}
             displayName.x = this.xOffset
             displayName.y = top
             displayName.render(guiGraphics, mouseX, mouseY, partialTick)

--- a/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
+++ b/src/main/kotlin/ru/octol1ttle/flightassistant/screen/system/SystemManagementList.kt
@@ -10,9 +10,13 @@ import net.minecraft.network.chat.Component
 import net.minecraft.resources.ResourceLocation
 import ru.octol1ttle.flightassistant.api.ModuleController
 import ru.octol1ttle.flightassistant.api.util.extensions.cautionColor
-import ru.octol1ttle.flightassistant.api.util.extensions.color
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.color
+*///?}
 import ru.octol1ttle.flightassistant.api.util.extensions.font
-import ru.octol1ttle.flightassistant.api.util.extensions.render
+//? if >=26 {
+/*import ru.octol1ttle.flightassistant.api.util.extensions.render
+*///?}
 import ru.octol1ttle.flightassistant.screen.components.FABaseList
 import ru.octol1ttle.flightassistant.screen.components.SmartStringWidget
 

--- a/src/main/templates/fabric.mod.json
+++ b/src/main/templates/fabric.mod.json
@@ -31,9 +31,9 @@
         ]
     },
     "depends": {
-        "fabricloader": ">=0.16.3",
+        "fabricloader": "${flmin}",
         "minecraft": "${mc}",
-        "java": ">=17",
+        "java": "${javamin}",
         "architectury": "*",
         "fabric-language-kotlin": "*",
         "yet_another_config_lib_v3": "*"

--- a/src/main/templates/flightassistant.mixins.json
+++ b/src/main/templates/flightassistant.mixins.json
@@ -10,6 +10,7 @@
         "gui.GuiMixinLayeredDraw",
         "gui.GuiMixinLegacy",
         "gui.GuiMixinNew",
+        "gui.GuiMixinHud26",
         "level_renderer.LevelRendererMixinLegacy",
         "level_renderer.LevelRendererMixinNewest",
         "level_renderer.LevelRendererMixinNewestest",

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    kotlin("jvm") version "2.2.0" apply false
-    kotlin("plugin.serialization") version "2.2.0" apply false
+    kotlin("jvm") version "2.4.10" apply false
+    kotlin("plugin.serialization") version "2.4.10" apply false
     id("dev.kikugie.stonecutter")
     id("me.modmuss50.mod-publish-plugin") version "0.8.4" apply false
 }
 
-stonecutter active "1.20.1-fabric" /* [SC] DO NOT EDIT */
+stonecutter active "26.2-fabric" /* [SC] DO NOT EDIT */
 
 allprojects {
     repositories {

--- a/versions/1.20.1-fabric/gradle.properties
+++ b/versions/1.20.1-fabric/gradle.properties
@@ -1,4 +1,4 @@
-modstitch.platform=loom
+modstitch.platform=fabric-loom-remap
 
 # Global
 deps.parchment=2023.09.03

--- a/versions/1.21.1-fabric/gradle.properties
+++ b/versions/1.21.1-fabric/gradle.properties
@@ -1,4 +1,4 @@
-modstitch.platform=loom
+modstitch.platform=fabric-loom-remap
 
 # Global
 deps.parchment=2024.11.17

--- a/versions/1.21.11-fabric/gradle.properties
+++ b/versions/1.21.11-fabric/gradle.properties
@@ -1,4 +1,4 @@
-modstitch.platform=loom
+modstitch.platform=fabric-loom-remap
 
 # Global
 deps.parchment=2025.12.20

--- a/versions/1.21.6-fabric/gradle.properties
+++ b/versions/1.21.6-fabric/gradle.properties
@@ -1,4 +1,4 @@
-modstitch.platform=loom
+modstitch.platform=fabric-loom-remap
 
 # Global
 deps.parchment=2025.06.29

--- a/versions/1.21.9-fabric/gradle.properties
+++ b/versions/1.21.9-fabric/gradle.properties
@@ -1,4 +1,4 @@
-modstitch.platform=loom
+modstitch.platform=fabric-loom-remap
 
 # Global
 deps.parchment=2025.10.05

--- a/versions/26.2-fabric/gradle.properties
+++ b/versions/26.2-fabric/gradle.properties
@@ -1,0 +1,19 @@
+# Minecraft 26.2 is unobfuscated, so no remapping is required
+modstitch.platform=fabric-loom
+
+# Global
+deps.fabric_loader=0.19.3
+deps.flk=1.13.13
+deps.flk_kotlin=kotlin.2.4.10
+deps.yacl=3.9.6+26.2-fabric
+deps.arch_api=21.0.7
+
+# Fabric
+deps.fapi=0.156.0+26.2
+deps.modmenu=20.0.1
+deps.dabr=3.8.4+26.2-fabric
+
+# Mod
+mod.mc_version_range=26.2
+mod.mc_title=26.2
+mod.mc_targets=26.2


### PR DESCRIPTION
## Summary

Adds support for **Minecraft 26.2 (Fabric)**, which replaced the immediate-mode `GuiGraphics` rendering with a CPU-side render-state (extraction) model.

All changes are guarded with stonecutter version conditionals (`//? if >=26`), so the existing 1.20.1–1.21.11 versions are preserved and 26.2 is added as an additional supported version.

## What changed

- **Toolchain**: Kotlin 2.4.10, modstitch 0.8.5, fabric-loom 1.15.5
- **Java targeting**: per-version (25 for 26.x, 21 for 1.20.6+, 17 for older)
- Wire modstitch-generated (preprocessed) sources into the compile source set
- New `versions/26.2-fabric` version directory
- **HUD port to the render-state model**: `GuiGraphicsExtractor` shims in `GuiGraphicsCompat26.kt`, new `GuiMixinHud26` hook on `Hud.extractRenderState`, `extractContents`/`extractContent`/`extractRenderState` adaptations for screens, buttons and widgets
- **Mixin updates**: `LevelRenderer.render` (renamed from `renderLevel`) with `CameraRenderState`, `Camera` accessor via `gameRenderer.mainCamera()`
- **Projection fix**: 26.x uses a reversed-Z depth buffer, which broke the world→screen visibility check (`pos.z` range) — points behind the camera were mirrored back into view. `ScreenSpace.fromWorldSpace` now rejects points at/behind the camera plane (`clip.w <= 0`)

## Validation

- `:26.2-fabric:build` succeeds; the mod runs in-game on 26.2 (HUD, arrows, projection all verified).
- `:1.21.11-fabric:build` verified — the 26.x-only compat imports are version-gated and `GuiMixinHud26` is a `@Pseudo` mixin so older versions still compile.
- Other older versions (1.20.1–1.21.9) were not re-built locally; their code paths are unchanged and version-gated, but CI should re-run their builds.